### PR TITLE
fix: Lua module not found for config of math-conceal.nvim. #13

### DIFF
--- a/plugin/latex-conceal.lua
+++ b/plugin/latex-conceal.lua
@@ -1,1 +1,1 @@
-require("latex-conceal").setup({})
+-- require("latex-conceal").setup({})


### PR DESCRIPTION
#13 