### PR TITLE
fix: more strict rules for typst font detection

### DIFF
--- a/queries_config/typst/conceal_font.scm
+++ b/queries_config/typst/conceal_font.scm
@@ -8,7 +8,7 @@
   "(" @left_paren
   (#set! @left_paren conceal "")
   (formula
-    (_) @font_letter
+    (letter) @font_letter
     (#lua_func! @font_letter @typ_font_name "font"))
   ")" @right_paren
   (#set! @right_paren conceal ""))
@@ -25,3 +25,10 @@
   ; (#has-ancestor? @conceal math formula)
   ; (#set! @conceal "m"))
   (#lua_func! @typ_math_font "conceal"))
+
+; Script functions like upright, script, etc.
+(call
+  item: (ident) @func
+  (#any-of? @func "upright" "italic" "script" "mono" "sans")
+  (#has-ancestor? @func math formula)
+  (#set! conceal ""))

--- a/queries_config/typst/conceal_script.scm
+++ b/queries_config/typst/conceal_script.scm
@@ -80,13 +80,6 @@
   (#set! priority 98)
   (#set! conceal "" @sub_symbol)))
 
-; Script functions like upright, script, etc.
-(call
-  item: (ident) @func
-  (#any-of? @func "upright" "italic" "script" "cal" "frak" "mono" "sans" "bold")
-  (#has-ancestor? @func math formula)
-  (#set! conceal ""))
-
 ; Capture and conceal the opening parenthesis of the sub/supscript group
 ; For superscript with parentheses - hide both ^ and parentheses when content matches criteria
 (math


### PR DESCRIPTION
using node (letter) instead of (_) to capture the letter in font