### PR TITLE
fix: build config for rustflages in macos/linux

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,8 @@
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
+
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
+
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-Wl,-soname,liblookup_conceal.so"]

--- a/crates/conceal/Cargo.toml
+++ b/crates/conceal/Cargo.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
+default = ["lua51"]
 lua51 = ["mlua/lua51"]
 lua52 = ["mlua/lua52"] 
 lua53 = ["mlua/lua53"]


### PR DESCRIPTION
Based on the previous Makefile structure, add appropriate `rustflags` parameters to avoid errors.