### PR TITLE
chore: update rockspec

### DIFF
--- a/math-conceal.nvim-scm-1.rockspec
+++ b/math-conceal.nvim-scm-1.rockspec
@@ -42,12 +42,4 @@ end
 build = {
   type = 'builtin',
   copy_directories = {'ftplugin'},
-  install = {
-    lua = {
-      ["math-conceal.conceal"] = "lua/math-conceal/conceal.lua",
-      ["math-conceal.query"] = "lua/math-conceal/query.lua",
-      ["math-conceal.init"] = "lua/math-conceal/init.lua",
-      ["math-conceal.render"] = "lua/math-conceal/render.lua",
-    }
-  },
 }


### PR DESCRIPTION
builtin will copy lua/ automatically,
so build.install.lua is unnecessary
