### PR TITLE
perf: optimize render to compute visible range only

### DIFF
--- a/lua/math-conceal/render.lua
+++ b/lua/math-conceal/render.lua
@@ -1,7 +1,6 @@
 ---realization of fine grained math conceal rendering using neovim decoration provider API
 ---only expand conceal when the cursor is under the math node
 local M = {}
-local _uv = vim.uv
 local utils = require("math-conceal.utils")
 
 local latex = utils.init_queries_table("latex")
@@ -14,10 +13,24 @@ local queries = {
 
 local query_obj_cache = {}
 local buffer_cache = {}
+-- Viewport caching: store computed node lists per window
+local win_states = {}
+
 local ns_id = vim.api.nvim_create_namespace("math-conceal-render")
-local augroup = vim.api.nvim_create_augroup("math-conceal-render", { clear = false })
+local augroup = vim.api.nvim_create_augroup("math-conceal-render", { clear = true })
 
 local active_configs = {}
+
+-- Clean up window cache on window close
+vim.api.nvim_create_autocmd("WinClosed", {
+  group = augroup,
+  callback = function(args)
+    local win_id = tonumber(args.match)
+    if win_id then
+      win_states[win_id] = nil
+    end
+  end,
+})
 
 ---Get parsed query object from cache or parse a new one
 ---@param lang "latex" | "typst"
@@ -47,61 +60,104 @@ local function setup_decoration_provider()
         return false
       end
 
-      -- Ensure tree is up to date (parse is incremental, usually fast)
-      cache.parser:parse(true)
-      local trees = cache.parser:trees()
-      local tree = trees and trees[1]
-      if not tree then
-        return false
-      end
-      local root = tree:root()
+      -- Get current buffer version (changedtick)
+      local buf_tick = vim.b[buf_id].changedtick
 
+      -- Get or initialize window state
+      local state = win_states[win_id]
+      if not state then
+        state = { tick = -1, top = -1, bot = -1, marks = {} }
+        win_states[win_id] = state
+      end
+
+      -- Core optimization: cache hit check
+      -- Reuse marks if buffer unchanged AND viewport unchanged
+      local is_cache_valid = (state.tick == buf_tick) and (state.top == toprow) and (state.bot == botrow)
+
+      if not is_cache_valid then
+        -- Cache miss: requery Tree-sitter
+        state.marks = {}
+        state.tick = buf_tick
+        state.top = toprow
+        state.bot = botrow
+
+        -- Incremental parse (use true for full correctness)
+        cache.parser:parse(true)
+        local trees = cache.parser:trees()
+        local tree = trees and trees[1]
+
+        if tree then
+          local root = tree:root()
+          -- Query only visible range + small buffer (30 lines) for smooth scrolling
+          local query_top = math.max(0, toprow - 30)
+          local query_bot = botrow + 30
+
+          for id, node, metadata in cache.query:iter_captures(root, buf_id, query_top, query_bot) do
+            local capture_data = metadata[id]
+            local conceal_char = capture_data and capture_data.conceal or metadata.conceal
+
+            if conceal_char then
+              local r1, c1, r2, c2 = node:range()
+              -- Only cache marks within actual viewport
+              if r1 <= botrow and r2 >= toprow then
+                local priority = (capture_data and capture_data.priority) or metadata.priority or 100
+                local hl_group = (capture_data and capture_data.highlight) or metadata.highlight or "Conceal"
+
+                -- Store all rendering data in pure Lua table (array is faster than hash)
+                table.insert(state.marks, {
+                  r1,
+                  c1,
+                  r2,
+                  c2, -- [1-4] position
+                  conceal_char, -- [5]
+                  hl_group, -- [6]
+                  tonumber(priority) or 100, -- [7]
+                })
+              end
+            end
+          end
+        end
+      end
+
+      -- Render phase: ultra-fast iteration over cached Lua table
       local cursor = vim.api.nvim_win_get_cursor(win_id)
       local curr_row = cursor[1] - 1
       local curr_col = cursor[2]
       local set_extmark = vim.api.nvim_buf_set_extmark
 
-      -- Query only in visible range (core optimization: only query toprow to botrow)
-      for id, node, metadata in cache.query:iter_captures(root, buf_id, toprow, botrow) do
-        local capture_data = metadata[id]
-        local conceal_char = capture_data and capture_data.conceal or metadata.conceal
+      for _, m in ipairs(state.marks) do
+        local r1, c1, r2, c2 = m[1], m[2], m[3], m[4]
 
-        if conceal_char then
-          local r1, c1, r2, c2 = node:range()
-
-          -- Cursor collision detection logic remains the same
-          local is_cursor_inside = false
-          if curr_row >= r1 and curr_row <= r2 then
-            if r1 == r2 then
-              if curr_col >= c1 and curr_col < c2 then
-                is_cursor_inside = true
-              end
-            else
-              if curr_row == r1 and curr_col >= c1 then
-                is_cursor_inside = true
-              elseif curr_row == r2 and curr_col < c2 then
-                is_cursor_inside = true
-              elseif curr_row > r1 and curr_row < r2 then
-                is_cursor_inside = true
-              end
+        -- Collision detection: check if cursor is inside node
+        local is_cursor_inside = false
+        if curr_row >= r1 and curr_row <= r2 then
+          if r1 == r2 then
+            if curr_col >= c1 and curr_col < c2 then
+              is_cursor_inside = true
+            end
+          else
+            if curr_row == r1 and curr_col >= c1 then
+              is_cursor_inside = true
+            elseif curr_row == r2 and curr_col < c2 then
+              is_cursor_inside = true
+            elseif curr_row > r1 and curr_row < r2 then
+              is_cursor_inside = true
             end
           end
+        end
 
-          if not is_cursor_inside then
-            local priority = (capture_data and capture_data.priority) or metadata.priority or 100
-            local hl_group = (capture_data and capture_data.highlight) or metadata.highlight or "Conceal"
-
-            set_extmark(buf_id, ns_id, r1, c1, {
-              conceal = conceal_char,
-              hl_group = hl_group,
-              priority = tonumber(priority),
-              end_row = r2,
-              end_col = c2,
-              ephemeral = true,
-            })
-          end
+        if not is_cursor_inside then
+          set_extmark(buf_id, ns_id, r1, c1, {
+            conceal = m[5],
+            hl_group = m[6],
+            priority = m[7],
+            end_row = r2,
+            end_col = c2,
+            ephemeral = true,
+          })
         end
       end
+
       return false
     end,
   })
@@ -126,13 +182,11 @@ local function attach_to_buffer(buf, lang, query_string)
     return
   end
 
-  -- Only need to store parser and query, no longer need marks_by_row
   buffer_cache[buf] = {
     parser = parser,
     query = query,
   }
 
-  -- Only need to trigger redraw on tree changes, computation is done in on_win
   parser:register_cbs({
     on_changedtree = function()
       vim.schedule(function()
@@ -151,7 +205,6 @@ local function attach_to_buffer(buf, lang, query_string)
     end,
   })
 
-  -- Simple redraw trigger on cursor movement
   vim.api.nvim_create_autocmd({ "CursorMoved", "CursorMovedI" }, {
     group = augroup,
     buffer = buf,
@@ -162,14 +215,12 @@ local function attach_to_buffer(buf, lang, query_string)
 end
 
 ---Get conceal query string for a given language and list of names
----Includes both project-internal queries and Neovim runtime queries
 ---@param language "latex" | "typst"
 ---@param names string[]
 ---@return string conceal_query
 local function get_conceal_query(language, names)
   local output = {}
 
-  -- First, add project-internal conceal queries
   for _, name in ipairs(names) do
     name = "conceal_" .. name
     local conceal_querys = queries[language][name]
@@ -178,12 +229,9 @@ local function get_conceal_query(language, names)
     end
   end
 
-  -- Then, add default Neovim runtime queries
-  -- Try to get the default conceal query from Neovim's runtime
   local default_query_files = vim.treesitter.query.get_files(language, "highlights")
   if default_query_files and #default_query_files > 0 then
     for _, file_path in ipairs(default_query_files) do
-      -- Skip files that are already in our project
       if not file_path:find("math%-conceal") then
         local file = io.open(file_path, "r")
         if file then
@@ -227,7 +275,6 @@ function M.setup(opts, lang)
   local parser_lang = utils.lang_to_lt(lang)
 
   local query_string = get_conceal_query(parser_lang, conceal)
-  -- HACK: remove `; extends` from query to avoid unexpected behavior of inheriting Neovim's default queries
   query_string = query_string:gsub("; extends [^\n]+", "")
   active_configs[lang] = {
     file_lang = file_lang,


### PR DESCRIPTION
Replace full-file pre-computation with real-time visible area computation. Remove marks_by_row caching that caused input lag on large files. Query tree-sitter only for toprow-botrow range in on_win callback.

Benefits:
- Eliminates full-file traversal during typing
- Rendering cost now O(visible_lines) instead of O(file_size)
- Reduces memory usage for large files
- Incremental parsing remains fast