### PR TITLE
WIP: init by treesitters language attached to buffer

### DIFF
--- a/lua/math-conceal/init.lua
+++ b/lua/math-conceal/init.lua
@@ -1,173 +1,145 @@
-local queries = require("math-conceal.query")
+--- init.lua - Math Conceal plugin entry point
+--- Simplified configuration and setup
+local M = {}
+
+local loader = require("math-conceal.loader")
 local render = require("math-conceal.render")
-local M = {
-  files = {},
-  queries = {},
-  -- Default options
-  --- @type MathConcealOptions
-  opts = {
-    conceal = {
-      "greek",
-      "script",
-      "math",
-      "font",
-      "delim",
-      "phy",
-    },
-    ft = { "plaintex", "tex", "context", "bibtex", "markdown", "typst" },
-    depth = 90,
-    ns_id = 0,
-    highlights = {
-      ["@_cmd"] = { link = "@conceal" },
-      ["@cmd"] = { link = "@conceal" },
-      ["@func"] = { link = "@conceal" },
-      ["@font_letter"] = { link = "@conceal" },
-      ["@sub"] = { link = "@conceal" },
-      ["@sub_ident"] = { link = "@conceal" },
-      ["@sub_letter"] = { link = "@conceal" },
-      ["@sub_number"] = { link = "@conceal" },
-      ["@sup"] = { link = "@conceal" },
-      ["@sup_ident"] = { link = "@conceal" },
-      ["@sup_letter"] = { link = "@conceal" },
-      ["@sup_number"] = { link = "@conceal" },
-      ["@symbol"] = { link = "@conceal" },
-      ["@typ_font_name"] = { link = "@conceal" },
-      ["@typ_greek_symbol"] = { link = "@conceal" },
-      ["@typ_inline_dollar"] = { link = "@conceal" },
-      ["@typ_math_delim"] = { link = "@conceal" },
-      ["@typ_math_font"] = { link = "@conceal" },
-      ["@typ_math_symbol"] = { link = "@conceal" },
-      ["@typ_phy_symbol"] = { link = "@conceal" },
-      ["@conceal"] = { link = "@conceal" },
-      ["@open1"] = { link = "@conceal" },
-      ["@open2"] = { link = "@conceal" },
-      ["@close1"] = { link = "@conceal" },
-      ["@close2"] = { link = "@conceal" },
-      ["@punctuation"] = { link = "@conceal" },
-      ["@left_paren"] = { link = "@conceal" },
-      ["@right_paren"] = { link = "@conceal" },
-    },
+
+--- @class MathConcealOptions
+--- @field conceal string[]? Conceal types to enable (e.g., "greek", "script", "math", "font", "delim", "phy")
+--- @field ft string[]? Filetypes to enable conceal
+--- @field ns_id integer? Namespace ID for highlights
+--- @field highlights table<string, table<string, string>>? Highlight group definitions
+
+--- @type MathConcealOptions
+local default_opts = {
+  conceal = { "greek", "script", "math", "font", "delim", "phy" },
+  ft = { "plaintex", "tex", "context", "bibtex", "markdown", "typst" },
+  ns_id = 0,
+  highlights = {
+    ["@_cmd"] = { link = "@conceal" },
+    ["@cmd"] = { link = "@conceal" },
+    ["@func"] = { link = "@conceal" },
+    ["@font_letter"] = { link = "@conceal" },
+    ["@sub"] = { link = "@conceal" },
+    ["@sub_ident"] = { link = "@conceal" },
+    ["@sub_letter"] = { link = "@conceal" },
+    ["@sub_number"] = { link = "@conceal" },
+    ["@sup"] = { link = "@conceal" },
+    ["@sup_ident"] = { link = "@conceal" },
+    ["@sup_letter"] = { link = "@conceal" },
+    ["@sup_number"] = { link = "@conceal" },
+    ["@symbol"] = { link = "@conceal" },
+    ["@typ_font_name"] = { link = "@conceal" },
+    ["@typ_greek_symbol"] = { link = "@conceal" },
+    ["@typ_inline_dollar"] = { link = "@conceal" },
+    ["@typ_math_delim"] = { link = "@conceal" },
+    ["@typ_math_font"] = { link = "@conceal" },
+    ["@typ_math_symbol"] = { link = "@conceal" },
+    ["@typ_phy_symbol"] = { link = "@conceal" },
+    ["@conceal"] = { link = "@conceal" },
+    ["@open1"] = { link = "@conceal" },
+    ["@open2"] = { link = "@conceal" },
+    ["@close1"] = { link = "@conceal" },
+    ["@close2"] = { link = "@conceal" },
+    ["@punctuation"] = { link = "@conceal" },
+    ["@left_paren"] = { link = "@conceal" },
+    ["@right_paren"] = { link = "@conceal" },
+    ["@tex_greek"] = { link = "@conceal" },
+    ["@tex_font_name"] = { link = "@conceal" },
   },
 }
 
---- TODO: add custum_function setup
+--- @type MathConcealOptions
+M.opts = vim.deepcopy(default_opts)
 
---- @class custum_function
---- @field custum_functions table<string, function>: A table of custom functions to be used for concealment.
+-- Track if we've done initial setup
+local initialized = false
 
---- @class MathConcealOptions
---- @field conceal string[]?: Enable or disable math symbol concealment. You can add your own custom conceal types here. Default is {"greek", "script", "math", "font", "delim"}.
---- @field ft string[]: A list of filetypes to enable conceal
---- @field depth integer
---- @field augroup_id integer?
---- @field ns_id integer
---- @field highlights table<string, table<string, string>>
+--- Ensure the plugin is initialized (lazy init on first use)
+local function ensure_initialized()
+  if initialized then
+    return
+  end
+  initialized = true
 
----set up
----@param opts MathConcealOptions?
-function M.setup(opts)
-  M.opts = vim.tbl_deep_extend("force", M.opts, opts or {})
+  -- Setup loader with current options
+  loader.setup({
+    conceal = M.opts.conceal,
+    ft = M.opts.ft,
+    ns_id = M.opts.ns_id,
+    highlights = M.opts.highlights,
+  })
 end
 
----check if `filetype` is in `M.opts.ft`.
----if true, call `set_hl`
----@param filetype string?
+--- Setup the math-conceal plugin
+--- @param opts MathConcealOptions?
+function M.setup(opts)
+  M.opts = vim.tbl_deep_extend("force", default_opts, opts or {})
+  initialized = false -- Reset so next ensure_initialized() uses new opts
+  ensure_initialized()
+end
+
+--- Enable conceal for current buffer
+--- Called from ftplugin files
+--- @param filetype string?
 function M.set(filetype)
   filetype = filetype or vim.bo.filetype
-  for _, ft in ipairs(M.opts.ft) do
-    if ft == filetype then
-      M.set_hl(filetype)
-    end
+
+  -- Lazy initialize on first use
+  ensure_initialized()
+
+  -- Check if this filetype is supported
+  if not loader.is_supported_filetype(filetype) then
+    return
   end
+
+  -- Attach conceal to current buffer
+  loader.attach(0, filetype)
 end
 
----do some prepare work, then call `set_highlights`
----@param filetype string
+--- Alias for backward compatibility
+--- @param filetype string
 function M.set_hl(filetype)
-  -- force set conceallevel and concealcursor for current buffer
-  vim.opt_local.conceallevel = 2
-  vim.opt_local.concealcursor = "nci"
-
-  -- set typst math conceal for typst
-  -- and set latex math conceal for all other filetypes.
-  ---@type "typst" | "latex"
-  local lang = filetype == "typst" and filetype or "latex"
-
-  --- first run
-  if #M.queries == 0 then
-    for name, val in pairs(M.opts.highlights) do
-      vim.api.nvim_set_hl(M.opts.ns_id, name, val)
-    end
-    queries.load_queries()
-  end
-
-  --- after editing preamble and save, reset highlights
-  if filetype == "tex" then
-    M.opts.augroup_id = M.opts.augroup_id or vim.api.nvim_create_augroup("math-conceal", {})
-    vim.api.nvim_create_autocmd("BufWritePost", {
-      group = M.opts.augroup_id,
-      buffer = 0,
-      callback = function()
-        M.set_highlights("latex", M.queries.latex, "tex")
-        vim.treesitter.start()
-      end,
-    })
-  end
-
-  ---always reset highlights for tex due to preamble
-  local should_set_hl = filetype == "tex"
-
-  local langs_to_setup = { lang }
-
-  -- Check if buffer has treesitter parser and detect injected languages
-  local buf = vim.api.nvim_get_current_buf()
-  local ok, parser = pcall(vim.treesitter.get_parser, buf)
-  if ok and parser then
-    -- Get all language trees (including injections)
-    parser:for_each_tree(function(tree, language_tree)
-      local tree_lang = language_tree:lang()
-      if tree_lang == "latex" and not vim.tbl_contains(langs_to_setup, "latex") then
-        table.insert(langs_to_setup, "latex")
-      elseif tree_lang == "typst" and not vim.tbl_contains(langs_to_setup, "typst") then
-        table.insert(langs_to_setup, "typst")
-      end
-    end)
-  end
-
-  -- Setup all required languages
-  for _, l in ipairs(langs_to_setup) do
-    if M.queries[l] == nil then
-      M.files[l] = queries.get_conceal_queries(l, M.opts.conceal)
-      M.queries[l] = queries.read_query_files(M.files[l])
-      render.setup(M.opts, l)
-      should_set_hl = true
-    end
-  end
-
-  if should_set_hl then
-    for _, l in ipairs(langs_to_setup) do
-      M.set_highlights(l, M.queries[l], filetype)
-    end
-  end
-
-  -- Attach all required languages to the buffer
-  render.attach(buf, langs_to_setup)
+  M.set(filetype)
 end
 
----set highlights for lang.
----if filetype == 'tex', update queries for preamble
----@param lang string
----@param code string?
----@param filetype string?
-function M.set_highlights(lang, code, filetype)
-  filetype = filetype or vim.bo.filetype
-  code = code or ""
+--- Refresh conceal for current buffer
+function M.refresh()
+  loader.refresh(0)
+end
 
-  if filetype == "tex" then
-    local conceal_map = queries.get_preamble_conceal_map()
-    code = code .. "\n" .. queries.update_latex_queries(conceal_map)
-  end
-  vim.treesitter.query.set(lang, "highlights", code)
+--- Disable conceal for current buffer
+function M.disable()
+  loader.detach(0)
+end
+
+--- Check if conceal is active for current buffer
+--- @return boolean
+function M.is_active()
+  return render.is_attached(0)
+end
+
+--- Get currently active languages for the buffer
+--- @return string[]
+function M.get_active_langs()
+  return render.get_registered_langs(0)
+end
+
+--- Manually register a custom query for a buffer
+--- Useful for extending conceal behavior
+--- @param buf integer Buffer number (0 for current)
+--- @param lang string Tree-sitter language
+--- @param query_string string SCM query string
+--- @return boolean success
+function M.register_custom_query(buf, lang, query_string)
+  return render.register_query(buf, lang, query_string)
+end
+
+--- Invalidate query cache (call when query files change)
+--- @param lang string? Language to invalidate (nil for all)
+function M.invalidate_cache(lang)
+  loader.invalidate_cache(lang)
 end
 
 return M

--- a/lua/math-conceal/loader.lua
+++ b/lua/math-conceal/loader.lua
@@ -1,0 +1,333 @@
+--- loader.lua - Query loading and buffer attachment
+--- Responsible for: attach buffer → parse TS highlighters → load SCM queries → register to render
+local M = {}
+
+local query_utils = require("math-conceal.query")
+local render = require("math-conceal.render")
+
+--- @class LoaderConfig
+--- @field conceal string[] Conceal types to enable (e.g., "greek", "script", "math", "font", "delim", "phy")
+--- @field ft string[] Filetypes to enable conceal
+--- @field ns_id integer Namespace ID
+--- @field highlights table<string, table<string, string>> Highlight group definitions
+
+--- @type LoaderConfig
+local config = {
+  conceal = { "greek", "script", "math", "font", "delim", "phy" },
+  ft = { "plaintex", "tex", "context", "bibtex", "markdown", "typst" },
+  ns_id = 0,
+  highlights = {},
+}
+
+-- Track loaded queries per language to avoid redundant loading
+local loaded_langs = {}
+
+-- Track query file content per language
+local query_files_cache = {}
+local query_content_cache = {}
+
+-- Augroup for buffer-specific autocmds
+local augroup = vim.api.nvim_create_augroup("math-conceal-loader", { clear = true })
+
+-- Get plugin root directory
+local plugin_root = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":h")
+local symbols_dir = plugin_root .. "/symbols"
+
+--- Map filetype to tree-sitter language
+--- @param filetype string
+--- @return "latex"|"typst"
+local function filetype_to_lang(filetype)
+  if filetype == "typst" then
+    return "typst"
+  end
+  return "latex"
+end
+
+--- Strip "; extends" directive from query content
+--- @param content string Query content
+--- @return string Cleaned content
+local function strip_extends_directive(content)
+  -- Remove lines that start with "; extends" (with optional whitespace)
+  local result = content:gsub("^;%s*extends[^\n]*\n?", ""):gsub("\n;%s*extends[^\n]*", "")
+  return result
+end
+
+--- Read and concatenate query files
+--- @param files string[] List of file paths
+--- @return string Concatenated query content
+local function read_query_files(files)
+  local contents = {}
+  for _, file in ipairs(files) do
+    local f = io.open(file, "r")
+    if f then
+      local content = f:read("*a")
+      f:close()
+      -- Strip extends directive
+      content = strip_extends_directive(content)
+      table.insert(contents, content)
+    end
+  end
+  return table.concat(contents, "\n")
+end
+
+--- Get all conceal query files for a language from plugin's symbols directory
+--- @param lang "latex"|"typst"
+--- @param conceal_types string[] List of conceal types
+--- @return string[] List of query file paths
+local function get_conceal_query_files(lang, conceal_types)
+  local files = {}
+  local lang_dir = symbols_dir .. "/" .. lang
+
+  for _, name in ipairs(conceal_types) do
+    local query_file = lang_dir .. "/conceal_" .. name .. ".scm"
+    -- Check if file exists
+    local f = io.open(query_file, "r")
+    if f then
+      f:close()
+      table.insert(files, query_file)
+    end
+  end
+
+  return files
+end
+
+--- Get highlight query files for a language (from standard treesitter paths)
+--- @param lang "latex"|"typst"
+--- @return string[] List of query file paths
+local function get_highlight_query_files(lang)
+  return vim.treesitter.query.get_files(lang, "highlights")
+end
+
+--- Load and cache query content for a language
+--- @param lang "latex"|"typst"
+--- @return string Query content
+local function load_lang_queries(lang)
+  if query_content_cache[lang] then
+    return query_content_cache[lang]
+  end
+
+  -- Get all query files: highlights + conceal types
+  local files = get_highlight_query_files(lang)
+  local conceal_files = get_conceal_query_files(lang, config.conceal)
+  vim.list_extend(files, conceal_files)
+
+  query_files_cache[lang] = files
+  local content = read_query_files(files)
+  query_content_cache[lang] = content
+
+  return content
+end
+
+--- Build final query string for a language, optionally with preamble additions
+--- @param lang "latex"|"typst"
+--- @param buf integer Buffer number (for preamble detection)
+--- @return string Final query content
+local function build_query_string(lang, buf)
+  local base_content = load_lang_queries(lang)
+
+  -- For tex files with latex language, add preamble-defined commands
+  local filetype = vim.bo[buf].filetype
+  if filetype == "tex" and lang == "latex" then
+    local conceal_map = query_utils.get_preamble_conceal_map(buf)
+    local preamble_queries = query_utils.update_latex_queries(conceal_map)
+    if preamble_queries and #preamble_queries > 0 then
+      base_content = base_content .. "\n" .. preamble_queries
+    end
+  end
+
+  return base_content
+end
+
+--- Detect all tree-sitter languages used in a buffer (including injections)
+--- @param buf integer Buffer number
+--- @return string[] List of language names (all languages, not just latex/typst)
+local function detect_buffer_languages(buf)
+  local langs = {}
+  local seen = {}
+
+  local ok, parser = pcall(vim.treesitter.get_parser, buf)
+  if not ok or not parser then
+    return langs
+  end
+
+  -- Parse to ensure injections are loaded
+  pcall(parser.parse, parser)
+
+  parser:for_each_tree(function(_, language_tree)
+    local lang = language_tree:lang()
+    if not seen[lang] then
+      seen[lang] = true
+      table.insert(langs, lang)
+    end
+  end)
+
+  return langs
+end
+
+--- Check if a language is supported for conceal
+--- @param lang string
+--- @return boolean
+local function is_supported_lang(lang)
+  return lang == "latex" or lang == "typst"
+end
+
+--- Register directives if not already done
+local directives_registered = false
+local function ensure_directives_registered()
+  if directives_registered then
+    return
+  end
+  query_utils.load_queries()
+  directives_registered = true
+end
+
+--- Attach conceal rendering to a buffer
+--- This takes over the treesitter highlight pipeline for supported languages
+--- @param buf integer Buffer number (0 for current)
+--- @param filetype string? Filetype (defaults to buffer's filetype)
+function M.attach(buf, filetype)
+  if buf == 0 then
+    buf = vim.api.nvim_get_current_buf()
+  end
+  filetype = filetype or vim.bo[buf].filetype
+
+  -- Skip if already attached
+  if render.is_attached(buf) then
+    return
+  end
+
+  -- Ensure directives are registered
+  ensure_directives_registered()
+
+  -- Set conceal options
+  vim.api.nvim_set_option_value("conceallevel", 2, { win = 0 })
+  vim.api.nvim_set_option_value("concealcursor", "nc", { win = 0 })
+
+  -- Detect all languages in buffer (including injections)
+  local all_langs = detect_buffer_languages(buf)
+
+  -- Fallback: if no parser available yet, use filetype mapping
+  if #all_langs == 0 then
+    local primary_lang = filetype_to_lang(filetype)
+    all_langs = { primary_lang }
+  end
+
+  -- For each supported language, override its highlights query
+  for _, lang in ipairs(all_langs) do
+    if is_supported_lang(lang) then
+      local query_string = build_query_string(lang, buf)
+      -- Override the highlights query for this language
+      vim.treesitter.query.set(lang, "highlights", query_string)
+    end
+  end
+
+  -- Register with render to track attachment state
+  -- We pass a dummy query since highlights are set via vim.treesitter.query.set
+  for _, lang in ipairs(all_langs) do
+    if is_supported_lang(lang) then
+      render.register_query(buf, lang, "")
+    end
+  end
+
+  -- For tex files, setup auto-refresh on save (preamble changes)
+  if filetype == "tex" then
+    vim.api.nvim_create_autocmd("BufWritePost", {
+      group = augroup,
+      buffer = buf,
+      callback = function()
+        M.refresh(buf)
+      end,
+    })
+  end
+end
+
+--- Refresh conceal for a buffer (re-parse preamble, re-register queries)
+--- @param buf integer Buffer number (0 for current)
+function M.refresh(buf)
+  if buf == 0 then
+    buf = vim.api.nvim_get_current_buf()
+  end
+
+  local filetype = vim.bo[buf].filetype
+
+  -- Invalidate query cache to force reload
+  for _, lang in ipairs({ "latex", "typst" }) do
+    query_content_cache[lang] = nil
+  end
+
+  -- Re-detect languages
+  local all_langs = detect_buffer_languages(buf)
+  if #all_langs == 0 then
+    all_langs = { filetype_to_lang(filetype) }
+  end
+
+  -- Re-set highlights queries for supported languages
+  for _, lang in ipairs(all_langs) do
+    if is_supported_lang(lang) then
+      local query_string = build_query_string(lang, buf)
+      vim.treesitter.query.set(lang, "highlights", query_string)
+    end
+  end
+
+  -- Restart treesitter to apply new queries
+  vim.treesitter.stop(buf)
+  vim.schedule(function()
+    vim.treesitter.start(buf)
+  end)
+end
+
+--- Detach conceal from a buffer
+--- @param buf integer Buffer number (0 for current)
+function M.detach(buf)
+  if buf == 0 then
+    buf = vim.api.nvim_get_current_buf()
+  end
+  render.clear_buffer(buf)
+end
+
+--- Setup loader with configuration
+--- @param opts LoaderConfig?
+function M.setup(opts)
+  config = vim.tbl_deep_extend("force", config, opts or {})
+
+  -- Setup highlights
+  for name, val in pairs(config.highlights) do
+    vim.api.nvim_set_hl(config.ns_id, name, val)
+  end
+
+  -- Setup and enable render engine
+  render.setup()
+  render.enable()
+end
+
+--- Invalidate query cache (useful when query files change)
+--- @param lang string? Language to invalidate (nil for all)
+function M.invalidate_cache(lang)
+  if lang then
+    query_content_cache[lang] = nil
+    query_files_cache[lang] = nil
+  else
+    query_content_cache = {}
+    query_files_cache = {}
+  end
+end
+
+--- Get supported languages
+--- @return string[]
+function M.get_supported_langs()
+  return { "latex", "typst" }
+end
+
+--- Check if a filetype should have conceal enabled
+--- @param filetype string
+--- @return boolean
+function M.is_supported_filetype(filetype)
+  for _, ft in ipairs(config.ft) do
+    if ft == filetype then
+      return true
+    end
+  end
+  return false
+end
+
+return M


### PR DESCRIPTION
This is useful for `injection` defined in tree-sitter. For example, tree-sitter parser for $\LaTeX$ would be injected into `markdown-inline` parser.
<img width="803" height="267" alt="example" src="https://github.com/user-attachments/assets/ed197d0f-01a0-4707-afcc-34cd57ec2f4e" />
