### PR TITLE
fix: harden typst symbol update workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -26,12 +26,26 @@ jobs:
         run: |
           SCRIPT_PATH="scripts/typst_symbols.rs"
 
-          LATEST_VERSION=$(cargo search typst --limit 1 | grep '^typst =' | sed -E 's/typst = "([^"]+)".*/\1/')
+          LATEST_VERSION=$(python3 - <<'PY'
+          import json
+          import urllib.request
+
+          with urllib.request.urlopen("https://crates.io/api/v1/crates/typst", timeout=30) as response:
+              data = json.load(response)
+
+          print(data["crate"]["newest_version"])
+          PY
+          )
 
           CURRENT_VERSION=$(grep 'typst = "' $SCRIPT_PATH | head -n 1 | sed -E 's/.*typst = "([^"]+)".*/\1/')
 
           echo "Latest Version:  $LATEST_VERSION"
           echo "Current Version: $CURRENT_VERSION"
+
+          if [ -z "$LATEST_VERSION" ] || [ -z "$CURRENT_VERSION" ]; then
+            echo "Failed to determine typst versions." >&2
+            exit 1
+          fi
 
           if [ "$LATEST_VERSION" != "$CURRENT_VERSION" ]; then
             echo "Update detected! Upgrading from $CURRENT_VERSION to $LATEST_VERSION"

--- a/scripts/typst_symbols.rs
+++ b/scripts/typst_symbols.rs
@@ -5,8 +5,6 @@
 //! typst-library = "0.14.2"
 //! serde = { version = "1.0", features = ["derive"] }
 //! serde_json = "1.0"
-//! reqwest = { version = "0.11", features = ["blocking", "json"] }
-//! semver = "1.0"
 //! ```
 use serde_json::json;
 use std::collections::BTreeMap;
@@ -16,49 +14,32 @@ use typst::foundations::{Scope, Symbol, Value};
 use typst::{Library, LibraryExt};
 
 fn main() {
-    let current_version = "0.14.2";
-    let latest_version = fetch_latest_typst_version().unwrap_or(current_version.to_string());
+    let lib = Library::default();
+    let global_scope = lib.global.scope();
 
-    if latest_version != current_version {
-        println!("New typst version detected: {latest_version}, updating symbols...");
-        let lib = Library::default();
-        let global_scope = lib.global.scope();
+    let mut symbol_map: BTreeMap<String, String> = BTreeMap::new();
 
-        let mut symbol_map: BTreeMap<String, String> = BTreeMap::new();
-
-        for (name, binding) in global_scope.iter() {
-            if name == "math" {
-                let value = binding.read();
-                if let Value::Module(module) = value {
-                    extract_from_scope(module.scope(), &mut symbol_map);
-                    break;
-                }
+    for (name, binding) in global_scope.iter() {
+        if name == "math" {
+            let value = binding.read();
+            if let Value::Module(module) = value {
+                extract_from_scope(module.scope(), &mut symbol_map);
+                break;
             }
         }
-
-        let output_json = json!({
-            "conceal": symbol_map
-        });
-
-        let mut file = File::create("../lua/math-conceal/conceal/math_symbols_typst.json")
-            .expect("Failed to create output file");
-        file.write_all(
-            serde_json::to_string_pretty(&output_json)
-                .expect("Failed to serialize JSON")
-                .as_bytes(),
-        )
-        .expect("Failed to write to output file");
-    } else {
-        println!("Typst is up to date ({current_version})");
     }
-}
 
-fn fetch_latest_typst_version() -> Option<String> {
-    let url = "https://crates.io/api/v1/crates/typst";
-    let resp = reqwest::blocking::get(url).ok()?;
-    let json: serde_json::Value = resp.json().ok()?;
-    let version = json.get("crate")?.get("newest_version")?.as_str()?;
-    Some(version.to_string())
+    let output_json = json!({
+        "conceal": symbol_map
+    });
+
+    let mut file = File::create("lua/math-conceal/conceal/math_symbols_typst.json")
+        .expect("Failed to create output file");
+    let mut serialized =
+        serde_json::to_string_pretty(&output_json).expect("Failed to serialize JSON");
+    serialized.push('\n');
+    file.write_all(serialized.as_bytes())
+        .expect("Failed to write to output file");
 }
 
 fn extract_from_scope(scope: &Scope, map: &mut BTreeMap<String, String>) {


### PR DESCRIPTION
## Summary
- fetch latest Typst version from the crates.io API instead of parsing cargo search output
- fail fast if either version cannot be determined
- make the Typst symbol generator write directly from the repository root and remove its duplicate network version check

## Verification
- python3 crates.io API check returned 0.14.2
- rust-script scripts/typst_symbols.rs
- git diff --check