### PR TITLE
fix: support markdown conceal specs

### DIFF
--- a/lua/math-conceal/init.lua
+++ b/lua/math-conceal/init.lua
@@ -84,9 +84,8 @@ end
 ---do some prepare work, then call `set_highlights`
 ---@param filetype string
 function M.set_hl(filetype)
-  -- force set conceallevel and concealcursor for current buffer
+  -- Enable conceal rendering while leaving cursor behavior to user config.
   vim.opt_local.conceallevel = 2
-  vim.opt_local.concealcursor = "nci"
 
   -- set typst math conceal for typst
   -- and set latex math conceal for all other filetypes.

--- a/lua/math-conceal/init.lua
+++ b/lua/math-conceal/init.lua
@@ -84,7 +84,6 @@ end
 ---do some prepare work, then call `set_highlights`
 ---@param filetype string
 function M.set_hl(filetype)
-  -- Enable conceal rendering while leaving cursor behavior to user config.
   vim.opt_local.conceallevel = 2
 
   -- set typst math conceal for typst
@@ -125,6 +124,17 @@ function M.set_hl(filetype)
     M.set_highlights(lang, M.queries[lang], filetype)
   end
 
+  if filetype == "markdown" then
+    for _, markdown_lang in ipairs({ "markdown", "markdown_inline" }) do
+      local key = "runtime:" .. markdown_lang
+      if M.queries[key] == nil then
+        M.files[key] = vim.treesitter.query.get_files(markdown_lang, "highlights")
+        M.queries[key] = queries.read_query_files(M.files[key])
+      end
+      M.set_highlights(markdown_lang, M.queries[key], filetype)
+    end
+  end
+
   -- Always try to attach render to current buffer
   render.attach(vim.api.nvim_get_current_buf(), lang)
 end
@@ -137,12 +147,16 @@ end
 function M.set_highlights(lang, code, filetype)
   filetype = filetype or vim.bo.filetype
   code = code or ""
+  local extra_code = ""
 
   if filetype == "tex" then
     local conceal_map = queries.get_preamble_conceal_map()
-    code = code .. "\n" .. queries.update_latex_queries(conceal_map)
+    extra_code = queries.update_latex_queries(conceal_map)
+    code = code .. "\n" .. extra_code
+    render.update_extra_query(lang, extra_code)
   end
-  vim.treesitter.query.set(lang, "highlights", code)
+
+  vim.treesitter.query.set(lang, "highlights", queries.strip_conceal_directives(code))
 end
 
 return M

--- a/lua/math-conceal/query.lua
+++ b/lua/math-conceal/query.lua
@@ -71,6 +71,90 @@ local function read_query_files(filenames)
   return table.concat(contents_table, "\n")
 end
 
+local conceal_directives = {
+  ["set-conceal!"] = true,
+  ["set-font!"] = true,
+  ["set-sub!"] = true,
+  ["set-sup!"] = true,
+  ["set-escape!"] = true,
+}
+
+local function find_directive_end(code, start)
+  local depth = 0
+  local in_string = false
+  local escaped = false
+
+  for i = start, #code do
+    local char = code:sub(i, i)
+
+    if in_string then
+      if escaped then
+        escaped = false
+      elseif char == "\\" then
+        escaped = true
+      elseif char == '"' then
+        in_string = false
+      end
+    elseif char == '"' then
+      in_string = true
+    elseif char == "(" then
+      depth = depth + 1
+    elseif char == ")" then
+      depth = depth - 1
+      if depth == 0 then
+        return i
+      end
+    end
+  end
+end
+
+local function is_conceal_directive(expr)
+  local directive = expr:match("^%(%#([%w%-%?!]+)")
+  if not directive then
+    return false
+  end
+
+  if conceal_directives[directive] then
+    return true
+  end
+
+  if directive == "set!" or directive == "set-pairs!" or directive == "lua_func!" then
+    return expr:find("conceal", 1, true) ~= nil
+  end
+
+  return false
+end
+
+local function strip_conceal_directives(code)
+  local output = {}
+  local i = 1
+
+  while i <= #code do
+    local directive_start = code:find("%(%#", i)
+    if not directive_start then
+      table.insert(output, code:sub(i))
+      break
+    end
+
+    table.insert(output, code:sub(i, directive_start - 1))
+
+    local directive_end = find_directive_end(code, directive_start)
+    if not directive_end then
+      table.insert(output, code:sub(directive_start))
+      break
+    end
+
+    local expr = code:sub(directive_start, directive_end)
+    if not is_conceal_directive(expr) then
+      table.insert(output, expr)
+    end
+
+    i = directive_end + 1
+  end
+
+  return table.concat(output)
+end
+
 ---set pairs in treesitter
 ---inspired from [latex.nvim](https://github.com/robbielyman/latex.nvim)
 ---@param match table<integer, TSNode[]>
@@ -486,5 +570,6 @@ M.update_latex_queries = update_latex_queries
 M.get_preamble_conceal_map = get_preamble_conceal_map
 M.get_conceal_queries = get_conceal_queries
 M.read_query_files = read_query_files
+M.strip_conceal_directives = strip_conceal_directives
 
 return M

--- a/lua/math-conceal/render.lua
+++ b/lua/math-conceal/render.lua
@@ -97,6 +97,55 @@ local function get_parsed_query(lang, query_string)
   end
 end
 
+local function strip_extends(query_string)
+  return query_string:gsub("; extends [^\n]+", "")
+end
+
+local function read_query_files(filenames)
+  local output = {}
+
+  for _, file_path in ipairs(filenames) do
+    if not file_path:find("math%-conceal") then
+      local file = io.open(file_path, "r")
+      if file then
+        local content = file:read("*a")
+        file:close()
+        if content and content ~= "" then
+          table.insert(output, content)
+        end
+      end
+    end
+  end
+
+  return table.concat(output, "\n")
+end
+
+local function get_runtime_highlights_query(language)
+  local files = vim.treesitter.query.get_files(language, "highlights")
+  if not files or #files == 0 then
+    return ""
+  end
+
+  return read_query_files(files)
+end
+
+local function make_spec(target_lang, query_string)
+  query_string = strip_extends(query_string or "")
+  if query_string == "" then
+    return
+  end
+
+  local query = get_parsed_query(target_lang, query_string)
+  if not query then
+    return
+  end
+
+  return {
+    target_lang = target_lang,
+    query = query,
+  }
+end
+
 local function collect_target_parsers(parser, parser_lang, target_lang, parsers)
   if parser_lang == target_lang then
     table.insert(parsers, parser)
@@ -115,7 +164,7 @@ local function collect_target_parsers(parser, parser_lang, target_lang, parsers)
   end
 end
 
-local function get_query_trees(cache)
+local function get_query_trees(cache, spec)
   local ok = pcall(function()
     cache.parser:parse(true)
   end)
@@ -125,7 +174,7 @@ local function get_query_trees(cache)
   end
 
   local parsers = {}
-  collect_target_parsers(cache.parser, cache.root_lang, cache.target_lang, parsers)
+  collect_target_parsers(cache.parser, cache.root_lang, spec.target_lang, parsers)
 
   local trees = {}
   for _, parser in ipairs(parsers) do
@@ -143,12 +192,44 @@ local function get_query_trees(cache)
   return trees
 end
 
-local function get_root_parser_lang(buf, lang)
-  if lang == "latex" and vim.bo[buf].filetype == "markdown" then
+local function get_root_parser_lang(buf, parser_lang)
+  if parser_lang == "latex" and vim.bo[buf].filetype == "markdown" then
     return "markdown"
   end
 
-  return lang
+  return parser_lang
+end
+
+local function get_buffer_specs(buf, config)
+  if config.parser_lang == "latex" and vim.bo[buf].filetype == "markdown" then
+    local specs = {}
+
+    local markdown_query = get_runtime_highlights_query("markdown")
+    local markdown_spec = make_spec("markdown", markdown_query)
+    if markdown_spec then
+      table.insert(specs, markdown_spec)
+    end
+
+    local markdown_inline_query = get_runtime_highlights_query("markdown_inline")
+    local markdown_inline_spec = make_spec("markdown_inline", markdown_inline_query)
+    if markdown_inline_spec then
+      table.insert(specs, markdown_inline_spec)
+    end
+
+    local latex_spec = make_spec("latex", config.query_string)
+    if latex_spec then
+      table.insert(specs, latex_spec)
+    end
+
+    return specs
+  end
+
+  local spec = make_spec(config.parser_lang, config.query_string)
+  if not spec then
+    return {}
+  end
+
+  return { spec }
 end
 
 ---Setup decoration provider for conceal rendering (global, only once)
@@ -156,7 +237,7 @@ local function setup_decoration_provider()
   vim.api.nvim_set_decoration_provider(ns_id, {
     on_win = function(_, win_id, buf_id, toprow, botrow)
       local cache = buffer_cache[buf_id]
-      if not cache or not cache.parser or not cache.query then
+      if not cache or not cache.parser or not cache.specs or #cache.specs == 0 then
         return false
       end
 
@@ -172,7 +253,10 @@ local function setup_decoration_provider()
 
       -- Core optimization: cache hit check
       -- Reuse marks if buffer unchanged AND viewport unchanged
-      local is_cache_valid = (state.tick == buf_tick) and (state.top == toprow) and (state.bot == botrow)
+      local is_cache_valid = (state.tick == buf_tick)
+        and (state.top == toprow)
+        and (state.bot == botrow)
+        and (state.version == cache.version)
 
       if not is_cache_valid then
         -- Cache miss: requery Tree-sitter
@@ -180,36 +264,39 @@ local function setup_decoration_provider()
         state.tick = buf_tick
         state.top = toprow
         state.bot = botrow
+        state.version = cache.version
 
         -- Incremental parse (use true for full correctness)
-        local trees = get_query_trees(cache)
-        for _, tree in ipairs(trees) do
-          local root = tree:root()
-          -- Query only visible range + small buffer (30 lines) for smooth scrolling
-          local query_top = math.max(0, toprow - 30)
-          local query_bot = botrow + 30
+        for _, spec in ipairs(cache.specs) do
+          local trees = get_query_trees(cache, spec)
+          for _, tree in ipairs(trees) do
+            local root = tree:root()
+            -- Query only visible range + small buffer (30 lines) for smooth scrolling
+            local query_top = math.max(0, toprow - 30)
+            local query_bot = botrow + 30
 
-          for id, node, metadata in cache.query:iter_captures(root, buf_id, query_top, query_bot) do
-            local capture_data = metadata[id]
-            local conceal_char = capture_data and capture_data.conceal or metadata.conceal
+            for id, node, metadata in spec.query:iter_captures(root, buf_id, query_top, query_bot) do
+              local capture_data = metadata[id]
+              local conceal_char = capture_data and capture_data.conceal or metadata.conceal
 
-            if conceal_char then
-              local r1, c1, r2, c2 = node:range()
-              -- Only cache marks within actual viewport
-              if r1 <= botrow and r2 >= toprow then
-                local priority = (capture_data and capture_data.priority) or metadata.priority or 100
-                local hl_group = (capture_data and capture_data.highlight) or metadata.highlight or "Conceal"
+              if conceal_char then
+                local r1, c1, r2, c2 = node:range()
+                -- Only cache marks within actual viewport
+                if r1 <= botrow and r2 >= toprow then
+                  local priority = (capture_data and capture_data.priority) or metadata.priority or 100
+                  local hl_group = (capture_data and capture_data.highlight) or metadata.highlight or "Conceal"
 
-                -- Store all rendering data in pure Lua table (array is faster than hash)
-                table.insert(state.marks, {
-                  r1,
-                  c1,
-                  r2,
-                  c2, -- [1-4] position
-                  conceal_char, -- [5]
-                  hl_group, -- [6]
-                  tonumber(priority) or 100, -- [7]
-                })
+                  -- Store all rendering data in pure Lua table (array is faster than hash)
+                  table.insert(state.marks, {
+                    r1,
+                    c1,
+                    r2,
+                    c2, -- [1-4] position
+                    conceal_char, -- [5]
+                    hl_group, -- [6]
+                    tonumber(priority) or 100, -- [7]
+                  })
+                end
               end
             end
           end
@@ -262,29 +349,32 @@ end
 
 ---Attach conceal logic to buffer
 ---@param buf number
----@param lang string
----@param query_string string
-local function attach_to_buffer(buf, lang, query_string)
-  if buffer_cache[buf] then
+---@param config table
+local function attach_to_buffer(buf, config)
+  local root_lang = get_root_parser_lang(buf, config.parser_lang)
+  local specs = get_buffer_specs(buf, config)
+  if #specs == 0 then
     return
   end
 
-  local query = get_parsed_query(lang, query_string)
-  if not query then
-    return
-  end
-
-  local root_lang = get_root_parser_lang(buf, lang)
   local parser = vim.treesitter.get_parser(buf, root_lang)
   if not parser then
     return
   end
 
+  if buffer_cache[buf] then
+    buffer_cache[buf].parser = parser
+    buffer_cache[buf].root_lang = root_lang
+    buffer_cache[buf].specs = specs
+    buffer_cache[buf].version = buffer_cache[buf].version + 1
+    return
+  end
+
   buffer_cache[buf] = {
     parser = parser,
-    query = query,
     root_lang = root_lang,
-    target_lang = lang,
+    specs = specs,
+    version = 1,
   }
 
   parser:register_cbs({
@@ -389,7 +479,7 @@ function M.attach(buf, lang)
     return
   end
 
-  attach_to_buffer(buf, config.parser_lang, config.query_string)
+  attach_to_buffer(buf, config)
 
   for _, win in ipairs(buf_wins(buf)) do
     redraw_win(win)
@@ -406,10 +496,12 @@ function M.setup(opts, lang)
   local parser_lang = utils.lang_to_lt(lang)
 
   local query_string = get_conceal_query(parser_lang, conceal)
-  query_string = query_string:gsub("; extends [^\n]+", "")
+  query_string = strip_extends(query_string)
   active_configs[lang] = {
     file_lang = file_lang,
     parser_lang = parser_lang,
+    base_query_string = query_string,
+    extra_query_string = "",
     query_string = query_string,
   }
 
@@ -418,6 +510,26 @@ function M.setup(opts, lang)
   if vim.bo.filetype == file_lang then
     M.attach(vim.api.nvim_get_current_buf(), lang)
   end
+end
+
+function M.update_query(lang, query_string)
+  local config = active_configs[lang]
+  if not config then
+    return
+  end
+
+  config.base_query_string = strip_extends(query_string or "")
+  config.query_string = config.base_query_string .. "\n" .. (config.extra_query_string or "")
+end
+
+function M.update_extra_query(lang, query_string)
+  local config = active_configs[lang]
+  if not config then
+    return
+  end
+
+  config.extra_query_string = strip_extends(query_string or "")
+  config.query_string = config.base_query_string .. "\n" .. config.extra_query_string
 end
 
 return M

--- a/lua/math-conceal/render.lua
+++ b/lua/math-conceal/render.lua
@@ -97,6 +97,60 @@ local function get_parsed_query(lang, query_string)
   end
 end
 
+local function collect_target_parsers(parser, parser_lang, target_lang, parsers)
+  if parser_lang == target_lang then
+    table.insert(parsers, parser)
+  end
+
+  local ok, children = pcall(function()
+    return parser:children()
+  end)
+
+  if not ok or not children then
+    return
+  end
+
+  for child_lang, child in pairs(children) do
+    collect_target_parsers(child, child_lang, target_lang, parsers)
+  end
+end
+
+local function get_query_trees(cache)
+  local ok = pcall(function()
+    cache.parser:parse(true)
+  end)
+
+  if not ok then
+    return {}
+  end
+
+  local parsers = {}
+  collect_target_parsers(cache.parser, cache.root_lang, cache.target_lang, parsers)
+
+  local trees = {}
+  for _, parser in ipairs(parsers) do
+    local parsed = pcall(function()
+      parser:parse(true)
+    end)
+
+    if parsed then
+      for _, tree in ipairs(parser:trees() or {}) do
+        table.insert(trees, tree)
+      end
+    end
+  end
+
+  return trees
+end
+
+local function get_root_parser_lang(buf, lang)
+  if lang == "latex" and vim.bo[buf].filetype == "markdown" then
+    return "markdown"
+  end
+
+  return lang
+end
+
 ---Setup decoration provider for conceal rendering (global, only once)
 local function setup_decoration_provider()
   vim.api.nvim_set_decoration_provider(ns_id, {
@@ -128,11 +182,8 @@ local function setup_decoration_provider()
         state.bot = botrow
 
         -- Incremental parse (use true for full correctness)
-        cache.parser:parse(true)
-        local trees = cache.parser:trees()
-        local tree = trees and trees[1]
-
-        if tree then
+        local trees = get_query_trees(cache)
+        for _, tree in ipairs(trees) do
           local root = tree:root()
           -- Query only visible range + small buffer (30 lines) for smooth scrolling
           local query_top = math.max(0, toprow - 30)
@@ -223,7 +274,8 @@ local function attach_to_buffer(buf, lang, query_string)
     return
   end
 
-  local parser = vim.treesitter.get_parser(buf, lang)
+  local root_lang = get_root_parser_lang(buf, lang)
+  local parser = vim.treesitter.get_parser(buf, root_lang)
   if not parser then
     return
   end
@@ -231,6 +283,8 @@ local function attach_to_buffer(buf, lang, query_string)
   buffer_cache[buf] = {
     parser = parser,
     query = query,
+    root_lang = root_lang,
+    target_lang = lang,
   }
 
   parser:register_cbs({


### PR DESCRIPTION
Previously, our plugin only supported single Treesitter conceal node analysis, an abstraction that was no longer sufficient for files like markdown that load multiple Treesitter parsers. The purpose of this PR is to address this issue at the markdown conceal level. This is the markdown alternative for PR #120.