### PR TITLE
doc: advertise preview equation conceal testing

### DIFF
--- a/.github/ISSUE_TEMPLATE/equation-conceal-preview.yml
+++ b/.github/ISSUE_TEMPLATE/equation-conceal-preview.yml
@@ -1,0 +1,85 @@
+name: Equation conceal preview feedback
+description: Report feedback for the preview graphical equation conceal path.
+title: "[preview] "
+labels:
+  - preview
+  - equation-conceal
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for testing the preview branch.
+
+        The stable `main` branch and LuaRocks release focus on ASCII/Unicode conceal.
+        Graphical equation conceal is currently tested on the `preview` branch.
+  - type: checkboxes
+    id: channel
+    attributes:
+      label: Channel
+      options:
+        - label: I am using `branch = "preview"` or an equivalent preview checkout.
+          required: true
+        - label: I understand ASCII/Unicode conceal is the stable path on `main`.
+          required: true
+  - type: dropdown
+    id: source-kind
+    attributes:
+      label: Source kind
+      options:
+        - Typst
+        - Markdown
+        - Markdown stream output
+        - Experimental LaTeX
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS
+      placeholder: "macOS 15.5, Ubuntu 24.04, Arch Linux, ..."
+    validations:
+      required: true
+  - type: input
+    id: terminal
+    attributes:
+      label: Terminal
+      placeholder: "kitty, Ghostty, WezTerm, ..."
+    validations:
+      required: true
+  - type: input
+    id: nvim-version
+    attributes:
+      label: Neovim version
+      placeholder: "nvim --version"
+    validations:
+      required: true
+  - type: textarea
+    id: config
+    attributes:
+      label: Minimal plugin config
+      render: lua
+      description: Include the relevant `math-conceal.nvim` setup or lazy.nvim spec.
+    validations:
+      required: true
+  - type: textarea
+    id: snippet
+    attributes:
+      label: Minimal source snippet
+      render: text
+      description: Include the smallest Typst, Markdown, or LaTeX snippet that shows the behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: behavior
+    attributes:
+      label: What happened?
+      description: Describe what you expected, what actually happened, and whether ASCII/Unicode conceal still works.
+    validations:
+      required: true
+  - type: textarea
+    id: messages
+    attributes:
+      label: Messages, logs, screenshots, or video
+      description: Paste relevant `:messages` output and attach screenshots or recordings if useful.
+      render: text

--- a/README.md
+++ b/README.md
@@ -6,6 +6,39 @@ Faster and More Precise [LaTeX](https://www.latex-project.org/) and [typst](http
 
 https://github.com/user-attachments/assets/65826ae2-2cd5-48a4-aa37-bfd3d9748b31
 
+## Preview Channel
+
+The stable `main` branch focuses on fast ASCII/Unicode math conceal. A preview
+branch is available for graphical equation conceal in Typst and Markdown, with
+experimental LaTeX rendering.
+
+### Typst Equation Conceal Preview
+
+https://github.com/user-attachments/assets/d78175a5-7462-40b6-be63-087fd100b97a
+
+Try the preview branch with lazy.nvim:
+
+```lua
+return {
+  "pxwg/math-conceal.nvim",
+  branch = "preview",
+  build = "cargo build --release --manifest-path service/Cargo.toml",
+  main = "math-conceal",
+  opts = {
+    conceal = { "greek", "script", "math", "font", "delim", "phy" },
+    ft = { "plaintex", "tex", "context", "bibtex", "markdown", "typst" },
+    image = {
+      enabled = true,
+      filetypes = { "typst", "markdown" },
+    },
+  },
+}
+```
+
+Feedback from Typst, Markdown streaming-output, and experimental LaTeX users is
+welcome. Please include your terminal, OS, Neovim version, filetype, a minimal
+snippet, and any `:messages` output.
+
 <table style="width: 80%; margin: auto; text-align: center;">
   <tr>
     <td style="width: 50%;">


### PR DESCRIPTION
## Summary

- Add a README preview channel section that keeps the stable main branch positioned as the ASCII/Unicode conceal path.
- Include the Typst equation conceal preview video and lazy.nvim preview branch install snippet.
- Add a GitHub issue template for preview graphical equation conceal feedback.

## Notes

This is documentation-only and does not merge the preview implementation into main.