### PR TITLE
fix(typst): inline math invisibility & display math cursor jump

### DIFF
--- a/lua/math-conceal/image/line-run.lua
+++ b/lua/math-conceal/image/line-run.lua
@@ -508,13 +508,34 @@ local function choose_line_run_anchor(bufnr, start_row, end_row, opts)
   local line_count = vim.api.nvim_buf_line_count(bufnr)
   local anchor_rows = opts and opts.anchor_rows or nil
 
-  -- Keep the visual replacement before the concealed source run whenever
-  -- possible. Anchoring to the next visible line with virt_lines_above makes
-  -- Neovim map screen-line movement back through a later buffer row, which can
-  -- cause k/gk to bounce between adjacent rows. Anchoring on the concealed row
-  -- itself is also problematic because it combines virt_lines and conceal_lines
-  -- on the same buffer row.
+  -- Prefer anchoring virt_lines to start_row itself with virt_lines_above so
+  -- the rendered image stays at the visual position of the concealed source
+  -- block.  This prevents cursor jumps to the top/bottom of the screen when
+  -- conceal is applied to a multi-line display math block.
+  -- Only fall back to start_row - 1 if start_row already has conflicting
+  -- virt_lines from another extmark in the secondary namespace.
   if start_row > 0 then
+    local ok, marks = pcall(
+      vim.api.nvim_buf_get_extmarks,
+      bufnr,
+      state.ns_id2,
+      { start_row, 0 },
+      { start_row, -1 },
+      { details = true }
+    )
+    local has_virt_lines_conflict = false
+    if ok and marks then
+      for _, mark in ipairs(marks) do
+        local details = mark[4] or {}
+        if details.virt_lines ~= nil then
+          has_virt_lines_conflict = true
+          break
+        end
+      end
+    end
+    if not has_virt_lines_conflict then
+      return start_row, true
+    end
     return start_row - 1, false
   end
 

--- a/lua/math-conceal/image/semantics.lua
+++ b/lua/math-conceal/image/semantics.lua
@@ -46,12 +46,6 @@ function M.classify(range, bufnr, node_type)
     if trimmed == formula_text then
       -- Single-line math occupying the whole trimmed line.
       display_kind = "block"
-    elseif formula_text:match("^%$%s+") and formula_text:match("%s+%$$") then
-      -- Typst treats `$ ... $` with inner-edge whitespace as display math even
-      -- when it appears inside surrounding markup. Keep the existing math node
-      -- capture, but upgrade it at render/display time to a whole-line block.
-      display_kind = "block"
-      render_whole_line = true
     else
       display_kind = "inline"
     end

--- a/lua/math-conceal/render.lua
+++ b/lua/math-conceal/render.lua
@@ -687,6 +687,31 @@ local function attach_to_buffer(buf, config)
       redraw_win(win, { top, bot })
     end,
   })
+
+  vim.api.nvim_create_autocmd("ModeChanged", {
+    group = augroup,
+    pattern = "i:n",
+    buffer = buf,
+    callback = function()
+      local win = vim.api.nvim_get_current_win()
+      if vim.api.nvim_win_get_buf(win) ~= buf then
+        return
+      end
+      local info = vim.fn.getwininfo(win)[1]
+      if not info then
+        vim.api.nvim__redraw({ win = win, valid = true, flush = true })
+        return
+      end
+      local top = info.topline - 1
+      local bot = info.botline
+      vim.api.nvim__redraw({
+        win = win,
+        valid = true,
+        flush = true,
+        range = { top, bot },
+      })
+    end,
+  })
 end
 
 ---Get conceal query string for a given language and list of names


### PR DESCRIPTION
## Summary

Fixes two rendering bugs when editing Typst files with the image overlay pipeline on kitty terminal:

1. **Inline math becomes invisible after cursor leaves the `$...$` region**
2. **Display math causes cursor line to jump to top/bottom of window + `j`/`k` navigation broken**

## Bug 1 Root Cause

The interaction between three mechanisms in `render.lua` created a timing gap where ephemeral conceal extmarks were cleared by Neovim but never re-applied:

- `ephemeral = true` extmarks (line 451) are auto-cleared between decoration-provider cycles.
- `CursorMoved` autocmd's `nvim__redraw(flush=false)` batches the redraw, so when `<Esc>` exits a formula the cleared marks aren't refreshed before the next screen paint.
- No `InsertLeave` / `InsertEnter` autocmd exists to handle mode transitions.

## Bug 2 Root Cause

Two independent issues in the display-math rendering path:

- `semantics.lua` classified **any** `$ x $` (Typst display math with content whitespace) as `display_kind="block"` + `render_whole_line=true`, regardless of whether the formula was alone on its line. This triggered `conceal_lines` on the whole source line, breaking Neovim's cursor navigation.
- `choose_line_run_anchor` in `line-run.lua` always anchored the virt_lines carrier to `start_row - 1` with `virt_lines_above=false`. As the source rows were simultaneously concealed, Neovim reflowed the screen, shifting the cursor to the top or bottom of the window.

## Changes

| File | Change |
|------|--------|
| `lua/math-conceal/render.lua` | Add `ModeChanged` autocmd for pattern `i:n` that forces `flush=true` viewport redraw, so `on_win` re-applies ephemeral conceal extmarks before the next screen update. |
| `lua/math-conceal/image/semantics.lua` | Remove the buggy `elseif` branch in `classify()`. A formula is now only treated as block display when it occupies **the entire trimmed line** (`trimmed == formula_text`). Mid-paragraph `$ x $` falls through to `inline`, preserving normal cursor movement. |
| `lua/math-conceal/image/line-run.lua` | Prefer anchoring virt_lines onto `start_row` itself with `virt_lines_above=true`, so the rendered image occupies the same visual position as the concealed source. A conflict check against other `ns_id2` virt_lines extmarks on `start_row` guards against double-anchoring; on conflict the previous `start_row - 1` fallback is retained. The `scan_safe` / `boundary_anchor` fallback logic is untouched. |

## Environment

- **Neovim**: v0.11.0
- **Terminal**: Kitty
- **Plugin manager**: lazy.nvim
- **Plugin commit**: `700e949` (`preview` branch)

## Commits

```
c7f48d8 fix(render): force viewport redraw on InsertLeave to restore inline math conceal
32f287f fix(image): anchor virt_lines on concealed row to prevent cursor jump
5b371a2 fix(image): classify single-line Typst display math as inline within paragraphs
```
