### PR TITLE
fix: avoid missing pathspec in symbol update workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -69,6 +69,6 @@ jobs:
         with:
           commit_message: "chore: update symbols to typst ${{ steps.update_process.outputs.version }}"
           branch: main
-          file_pattern: 'lua/ queries/ crates/ scripts/'
+          file_pattern: 'lua/ scripts/'
           commit_user_name: "github-actions[bot]"
           commit_user_email: "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary
- remove nonexistent `queries/` and `crates/` entries from the auto-commit file pattern
- keep Typst symbol update commits scoped to existing `lua/` and `scripts/` paths

## Verification
- ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "yaml ok"' .github/workflows/update.yml
- git add --dry-run lua/ scripts/
- git diff --check