### PR TITLE
Rapid editing may cause loss of the overlay image

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -125,8 +125,8 @@ A node slot materialized independently per editor window so each window can use 
 _Avoid_: Window extmark placement surface, fold-grid successor, buffer-global isolated block slot
 
 **Window-Local Slot Reveal**:
-The per-window source reveal state for Window Extmark Node Slots. It follows the existing source-reveal behavior: entering any part of the tracked source range reveals the whole tracked source range in that window, and leaving the source range restores conceal without forcing other windows showing the same buffer to close their node slots.
-_Avoid_: Buffer-global reveal state, cross-window slot teardown, shared cursor collision
+The per-window source reveal state for Window Extmark Node Slots. It follows the existing source-reveal behavior: entering any part of the tracked source range reveals the whole tracked source range in that window, and leaving the source range restores conceal without forcing other windows showing the same buffer to close their node slots. This is a visibility state, not a terminal-placement disposal state: `placed=false` means window-local slot extmarks are absent, while `placement_id` may remain live so the Kitty Unicode-placeholder virtual placement can be reused on restore. Hard lifecycle events, not cursor source reveal, own `delete_placement`.
+_Avoid_: Buffer-global reveal state, cross-window slot teardown, shared cursor collision, treating `placed=false` as terminal placement release
 
 **Carrier-Maximized Slot Height**:
 The Window Extmark Node Slot height principle that preserves the largest real source carrier footprint that fits within the rendered image height, then uses collapsed source rows and virtual image rows only to reconcile the visible slot height with the rendered asset. If the smallest useful carrier already wraps taller than the rendered asset, carrier continuity wins and the visible slot may be taller than the asset.

--- a/lua/math-conceal/image/placement/window-node-slot.lua
+++ b/lua/math-conceal/image/placement/window-node-slot.lua
@@ -190,15 +190,18 @@ local function release_terminal_placement(placement)
   placement.placement_id = nil
 end
 
-local function deactivate_placement(surface, placement)
+local function deactivate_placement(surface, placement, opts)
   if placement == nil then
     return
   end
+  opts = opts or {}
   local had_extmarks = #(placement.extmark_ids or {}) > 0
   local source_start_row = placement.source_start_row
   local source_end_row = placement.source_end_row
   clear_placement_extmarks(surface, placement)
-  release_terminal_placement(placement)
+  if opts.keep_terminal_placement ~= true then
+    release_terminal_placement(placement)
+  end
   placement.placed = false
   if had_extmarks and source_start_row ~= nil and source_end_row ~= nil then
     redraw_surface_range(surface, source_start_row, source_end_row)
@@ -761,7 +764,10 @@ local function materialize_placement(surface, placement, opts)
     if before == signature and not placement.placed and #(placement.extmark_ids or {}) == 0 then
       return true, false
     end
-    deactivate_placement(surface, placement)
+    -- Source reveal is a visibility transition, not hard disposal. Keep the
+    -- Kitty Unicode-placeholder virtual placement alive so restore can reuse
+    -- the same placement id; `placed=false` does not imply release.
+    deactivate_placement(surface, placement, { keep_terminal_placement = true })
     placement.signature = signature
     redraw_surface_range(surface, view.row, view.end_row)
     return true, before ~= placement.signature

--- a/scripts/test-window-node-slot-contract.lua
+++ b/scripts/test-window-node-slot-contract.lua
@@ -323,16 +323,15 @@ local function run()
   vim.api.nvim_win_set_cursor(win_a, { 3, 4 })
   vim.api.nvim_win_set_cursor(win_b, { 1, 0 })
   local redraw_count_before_reveal = #redraw_calls
+  local terminal_count_before_reveal = #terminal_calls
+  local placement_id_before_reveal = active_a.placement_id
   placement.refresh_geometry(bufnr, { keys = { [key] = true } })
   active_a = surface_a.placements[key]
   active_b = surface_b.placements[key]
   assert_eq("window A reveal clears placement", active_a.placed, false)
-  assert_eq("window A reveal releases terminal placement", active_a.placement_id, nil)
+  assert_eq("window A reveal keeps terminal placement id", active_a.placement_id, placement_id_before_reveal)
   assert_eq("window B keeps placement visible", active_b.placed, true)
-  assert_true(
-    "source reveal deletes one terminal placement",
-    terminal_calls[#terminal_calls].kind == "delete_placement"
-  )
+  assert_eq("source reveal does not hot-delete terminal placement", #terminal_calls, terminal_count_before_reveal)
   assert_true(
     "source reveal force-redraws source range",
     saw_forced_redraw(win_a, track.row, track.end_row + 1, redraw_count_before_reveal + 1)
@@ -342,7 +341,7 @@ local function run()
   placement.refresh_geometry(bufnr, { keys = { [key] = true } })
   active_a = surface_a.placements[key]
   assert_eq("window A restore places again", active_a.placed, true)
-  assert_true("window A restore allocates placement id", active_a.placement_id ~= nil)
+  assert_eq("window A restore reuses placement id", active_a.placement_id, placement_id_before_reveal)
 
   local terminal_count_before_uploaded_asset = #terminal_calls
   intent.asset.image_id = 0x223377
@@ -354,7 +353,13 @@ local function run()
     assert_true("uploaded asset does not resend image data", terminal_calls[index].kind ~= "send_image")
   end
 
+  local terminal_count_before_close_all = #terminal_calls
   placement.close_all(bufnr)
+  local saw_close_delete = false
+  for index = terminal_count_before_close_all + 1, #terminal_calls do
+    saw_close_delete = saw_close_delete or terminal_calls[index].kind == "delete_placement"
+  end
+  assert_true("hard close deletes terminal placements", saw_close_delete)
   vim.api.nvim__redraw = original_redraw
 end
 


### PR DESCRIPTION
The issue is that updates to the `live-preview` module have disrupted the original overlay image event stream. A more stable method needs to be established to implement the `live-preview` module.