### PR TITLE
perf(service): share render context across lanes

### DIFF
--- a/lua/math-conceal/image/preview.lua
+++ b/lua/math-conceal/image/preview.lua
@@ -587,6 +587,7 @@ local function render_projection_preview(bufnr, projection, track, cursor_row, c
   local req_id = request_id(bufnr)
   local payload = {
     type = "render_formulas",
+    lane = "preview",
     backend = ctx.backend or "typst",
     request_id = req_id,
     cache_key = preview_service_cache_key(projection, track, ctx, image.config),

--- a/lua/math-conceal/image/session.lua
+++ b/lua/math-conceal/image/session.lua
@@ -4,28 +4,30 @@ local M = {}
 local services = {}
 local send_next_payload
 
+-- One process per buffer, with independent request ownership per lane.
+local FULL_LANE = "full"
+local PREVIEW_LANE = "preview"
+
 local function notify(message, level)
   vim.schedule(function()
     vim.notify("[math-conceal.image] " .. message, level or vim.log.levels.WARN)
   end)
 end
 
-local function service_for(bufnr, kind)
-  kind = kind or "full"
-  services[bufnr] = services[bufnr] or {}
-  services[bufnr][kind] = services[bufnr][kind]
+local function service_for(bufnr)
+  services[bufnr] = services[bufnr]
     or {
       bufnr = bufnr,
-      kind = kind,
       line_buffer = "",
       stderr_buffer = "",
       active = {},
+      active_request_ids = {},
     }
-  return services[bufnr][kind]
+  return services[bufnr]
 end
 
-local function service_kind_for_meta(meta)
-  return meta ~= nil and meta.kind == "live_preview" and "preview" or "full"
+local function lane_for_meta(meta)
+  return meta ~= nil and meta.kind == "live_preview" and PREVIEW_LANE or FULL_LANE
 end
 
 local function same_full_context(left, right)
@@ -103,8 +105,8 @@ local function merged_full_request(existing, payload, meta)
   return merged
 end
 
-local function queue_payload(service, payload, meta)
-  if meta ~= nil and meta.kind == "live_preview" then
+local function queue_payload(service, lane, payload, meta)
+  if lane == PREVIEW_LANE then
     service.pending_preview = copy_request(payload, meta)
     return true
   end
@@ -115,7 +117,7 @@ local function queue_payload(service, payload, meta)
   return true
 end
 
-local function send_payload(service, payload, meta)
+local function send_payload(service, lane, payload, meta)
   local ok, json = pcall(vim.json.encode, payload)
   if not ok then
     notify("failed to encode render request: " .. tostring(json), vim.log.levels.ERROR)
@@ -126,14 +128,15 @@ local function send_payload(service, payload, meta)
   meta.expected = #(payload.nodes or {})
   meta.received = 0
   meta.request_id = payload.request_id
+  meta.lane = lane
   service.active[payload.request_id] = meta
-  service.active_request_id = payload.request_id
+  service.active_request_ids[lane] = payload.request_id
 
   local sent = vim.fn.chansend(service.job_id, json .. "\n")
   if sent == 0 then
     service.active[payload.request_id] = nil
-    if service.active_request_id == payload.request_id then
-      service.active_request_id = nil
+    if service.active_request_ids[lane] == payload.request_id then
+      service.active_request_ids[lane] = nil
     end
     notify("failed to write render request", vim.log.levels.ERROR)
     return false
@@ -169,19 +172,21 @@ local function pop_pending_full(service)
   return next_payload
 end
 
-send_next_payload = function(service)
-  if service == nil or service.active_request_id ~= nil or service.job_id == nil then
+send_next_payload = function(service, lane)
+  if service == nil or service.active_request_ids[lane] ~= nil or service.job_id == nil then
     return
   end
 
-  local next_payload = pop_pending_full(service)
-  if next_payload == nil then
+  local next_payload
+  if lane == PREVIEW_LANE then
     next_payload = service.pending_preview
     service.pending_preview = nil
+  else
+    next_payload = pop_pending_full(service)
   end
 
-  if next_payload ~= nil and not send_payload(service, next_payload.payload, next_payload.meta) then
-    send_next_payload(service)
+  if next_payload ~= nil and not send_payload(service, lane, next_payload.payload, next_payload.meta) then
+    send_next_payload(service, lane)
   end
 end
 
@@ -204,10 +209,11 @@ local function handle_line(service, line)
     meta.received = (meta.received or 0) + 1
     if meta.received >= (meta.expected or 1) then
       service.active[decoded.request_id] = nil
-      if service.active_request_id == decoded.request_id then
-        service.active_request_id = nil
+      local lane = meta.lane or FULL_LANE
+      if service.active_request_ids[lane] == decoded.request_id then
+        service.active_request_ids[lane] = nil
       end
-      send_next_payload(service)
+      send_next_payload(service, lane)
     end
   end
 end
@@ -243,8 +249,8 @@ local function on_stderr(bufnr, _, data)
   end
 end
 
-function M.ensure(bufnr, binding, kind)
-  local service = service_for(bufnr, kind)
+function M.ensure(bufnr, binding, _kind)
+  local service = service_for(bufnr)
   if service.job_id ~= nil and vim.fn.jobwait({ service.job_id }, 0)[1] == -1 then
     return service
   end
@@ -271,16 +277,11 @@ function M.ensure(bufnr, binding, kind)
       on_stderr(bufnr, job_id, data)
     end,
     on_exit = function(_, code)
-      local bucket = services[bufnr]
-      local current = bucket and bucket[service.kind] or nil
-      if current == service then
-        bucket[service.kind] = nil
-        if next(bucket) == nil then
-          services[bufnr] = nil
-        end
+      if services[bufnr] == service then
+        services[bufnr] = nil
       end
       if code ~= 0 and service.stopping ~= true then
-        notify(service.kind .. " service exited with code " .. tostring(code), vim.log.levels.WARN)
+        notify("service exited with code " .. tostring(code), vim.log.levels.WARN)
       end
     end,
   })
@@ -296,49 +297,62 @@ end
 
 function M.render_formulas(bufnr, binding, payload, meta)
   meta = meta or {}
-  local service = M.ensure(bufnr, binding, service_kind_for_meta(meta))
+  local lane = lane_for_meta(meta)
+  local service = M.ensure(bufnr, binding)
   if service == nil or service.job_id == nil then
     return false
   end
 
-  if service.active_request_id ~= nil then
-    return queue_payload(service, payload, meta)
+  if service.active_request_ids[lane] ~= nil then
+    return queue_payload(service, lane, payload, meta)
   end
 
-  return send_payload(service, payload, meta)
+  return send_payload(service, lane, payload, meta)
 end
 
 function M.render_code_flow(bufnr, binding, payload, meta)
   meta = meta or {}
   meta.kind = "code_flow_render"
-  local service = M.ensure(bufnr, binding, "full")
+  local service = M.ensure(bufnr, binding)
   if service == nil or service.job_id == nil then
     return false
   end
 
-  if service.active_request_id ~= nil then
-    return queue_payload(service, payload, meta)
+  if service.active_request_ids[FULL_LANE] ~= nil then
+    return queue_payload(service, FULL_LANE, payload, meta)
   end
 
-  return send_payload(service, payload, meta)
+  return send_payload(service, FULL_LANE, payload, meta)
 end
 
 function M.cancel_live_preview(bufnr)
-  local bucket = services[bufnr]
-  local service = bucket and bucket.preview or nil
+  local service = services[bufnr]
   if service ~= nil then
     service.pending_preview = nil
   end
 end
 
-local function service_idle(service)
+local function lane_idle(service, lane)
   if service == nil then
     return true
   end
-  return service.active_request_id == nil
-    and next(service.active or {}) == nil
-    and service.pending_preview == nil
-    and (service.pending_full == nil or next(service.pending_full) == nil)
+  if service.active_request_ids[lane] ~= nil then
+    return false
+  end
+  if lane == PREVIEW_LANE then
+    return service.pending_preview == nil
+  end
+  return service.pending_full == nil or next(service.pending_full) == nil
+end
+
+local function service_idle(service)
+  return lane_idle(service, FULL_LANE) and lane_idle(service, PREVIEW_LANE) and next(service.active or {}) == nil
+end
+
+local function reset_preview_lane(service)
+  if service ~= nil and service.job_id ~= nil then
+    pcall(vim.fn.chansend, service.job_id, vim.json.encode({ type = "reset_lane", lane = PREVIEW_LANE }) .. "\n")
+  end
 end
 
 local function stop_service(service)
@@ -350,50 +364,40 @@ local function stop_service(service)
 end
 
 function M.stop_if_idle(bufnr, kind)
-  local bucket = services[bufnr]
-  if bucket == nil then
+  local service = services[bufnr]
+  if service == nil then
     return true
   end
 
-  if kind ~= nil then
-    local service = bucket[kind]
-    if service == nil then
-      return true
-    end
-    if not service_idle(service) then
+  if kind == PREVIEW_LANE then
+    if not lane_idle(service, PREVIEW_LANE) then
       return false
     end
-    M.stop(bufnr, kind)
+    service.pending_preview = nil
+    reset_preview_lane(service)
     return true
   end
 
-  for _, service in pairs(bucket) do
-    if not service_idle(service) then
-      return false
-    end
+  if not service_idle(service) then
+    return false
   end
   M.stop(bufnr)
   return true
 end
 
 function M.stop(bufnr, kind)
-  local bucket = services[bufnr]
-  if bucket == nil then
+  local service = services[bufnr]
+  if service == nil then
     return
   end
 
-  if kind ~= nil then
-    stop_service(bucket[kind])
-    bucket[kind] = nil
-    if next(bucket) == nil then
-      services[bufnr] = nil
-    end
+  if kind == PREVIEW_LANE then
+    service.pending_preview = nil
+    reset_preview_lane(service)
     return
   end
 
-  for _, service in pairs(bucket) do
-    stop_service(service)
-  end
+  stop_service(service)
   services[bufnr] = nil
 end
 

--- a/lua/math-conceal/image/terminal.lua
+++ b/lua/math-conceal/image/terminal.lua
@@ -109,6 +109,7 @@ function M.upload(path, image_id, cols, rows)
   return M.place_image(image_id, nil, cols, rows)
 end
 
+-- Delete one placement while retaining image data shared by other placements.
 function M.delete_placement(image_id, placement_id)
   if image_id == nil or placement_id == nil then
     return
@@ -118,11 +119,12 @@ function M.delete_placement(image_id, placement_id)
   flush_if_unbatched()
 end
 
+-- Retire the image globally and ask the terminal to free its backing data.
 function M.delete_image(image_id)
   if image_id == nil then
     return
   end
-  queue("q=2,a=d,d=i,i=" .. image_id)
+  queue("q=2,a=d,d=I,i=" .. image_id)
   state.release_image_id(image_id)
   flush_if_unbatched()
 end

--- a/scripts/test-image-shared-service.lua
+++ b/scripts/test-image-shared-service.lua
@@ -1,0 +1,61 @@
+-- Run with:
+--   MATH_CONCEAL_SERVICE=service/target/release/typst-concealer-service \
+--     nvim --headless -u NONE '+luafile scripts/test-image-shared-service.lua'
+
+local function add_repo_to_path()
+  local cwd = vim.fn.getcwd()
+  vim.opt.runtimepath:append(cwd)
+  package.path = table.concat({
+    cwd .. "/lua/?.lua",
+    cwd .. "/lua/?/init.lua",
+    package.path,
+  }, ";")
+end
+
+local function assert_eq(label, actual, expected)
+  if actual ~= expected then
+    error(string.format("%s mismatch\nexpected: %q\nactual:   %q", label, tostring(expected), tostring(actual)), 2)
+  end
+end
+
+local function assert_true(label, value)
+  if not value then
+    error(label, 2)
+  end
+end
+
+local function run()
+  add_repo_to_path()
+  local binary = vim.env.MATH_CONCEAL_SERVICE or "service/target/release/typst-concealer-service"
+  assert_eq("service executable", vim.fn.executable(binary), 1)
+
+  local session = require("math-conceal.image.session")
+  local bufnr = vim.api.nvim_create_buf(false, true)
+  local binding = { service_binary = binary }
+  local full = session.ensure(bufnr, binding, "full")
+  local preview = session.ensure(bufnr, binding, "preview")
+
+  assert_true("full service starts", full ~= nil and full.job_id ~= nil)
+  assert_true("preview reuses full service", preview == full)
+  assert_eq("shared service pid", vim.fn.jobpid(preview.job_id), vim.fn.jobpid(full.job_id))
+
+  session.stop(bufnr, "preview")
+  assert_eq("preview lane reset keeps process alive", vim.fn.jobwait({ full.job_id }, 0)[1], -1)
+
+  session.stop(bufnr)
+  assert_true(
+    "shared service stops",
+    vim.wait(1000, function()
+      return vim.fn.jobwait({ full.job_id }, 0)[1] ~= -1
+    end, 10)
+  )
+end
+
+local ok, err = xpcall(run, debug.traceback)
+if not ok then
+  io.stderr:write(err .. "\n")
+  vim.cmd("cquit")
+end
+
+print("image-shared-service-ok")
+vim.cmd("qa!")

--- a/scripts/test-service-lanes.py
+++ b/scripts/test-service-lanes.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Exercise concurrent full/preview lanes through one service process."""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+
+binary = sys.argv[1] if len(sys.argv) > 1 else "service/target/release/typst-concealer-service"
+node_count = 80
+with tempfile.TemporaryDirectory(prefix="math-conceal-service-lanes-") as root:
+    def request(request_id: str, lane: str | None, count: int, workers: int) -> dict:
+        payload = {
+            "type": "render_formulas",
+            "request_id": request_id,
+            "cache_key": "lane-test",
+            "context_id": "lane-test",
+            "context_rev": 1,
+            "context_source": "",
+            "root": "/tmp",
+            "inputs": {},
+            "output_dir": os.path.join(root, request_id),
+            "ppi": 144,
+            "worker_count": workers,
+            "nodes": [
+                {
+                    "node_id": f"{request_id}:{index}",
+                    "node_rev": 1,
+                    "kind": "math",
+                    "source": (
+                        "#set page(width: auto, height: auto, margin: 0pt)\n"
+                        f"$ sum_(j=1)^{20 + index % 10} j^2 + frac(alpha_{index}, beta_{index}) $"
+                    ),
+                }
+                for index in range(count)
+            ],
+        }
+        if lane is not None:
+            payload["lane"] = lane
+        return payload
+
+    messages = [
+        request("full", None, node_count, 2),
+        request("preview", "preview", 1, 1),
+        {"type": "shutdown"},
+    ]
+    result = subprocess.run(
+        [binary],
+        input="".join(json.dumps(message, separators=(",", ":")) + "\n" for message in messages),
+        text=True,
+        capture_output=True,
+        check=True,
+        timeout=60,
+    )
+    responses = [json.loads(line) for line in result.stdout.splitlines() if line]
+    full = [item for item in responses if item.get("request_id") == "full"]
+    preview = [item for item in responses if item.get("request_id") == "preview"]
+
+    assert len(full) == node_count, (len(full), result.stderr)
+    assert len(preview) == 1, (len(preview), result.stderr)
+    preview_index = responses.index(preview[0])
+    last_full_index = max(index for index, item in enumerate(responses) if item.get("request_id") == "full")
+    assert preview_index < last_full_index, (preview_index, last_full_index)
+
+print("service-lanes-ok")

--- a/scripts/test-terminal-batch.lua
+++ b/scripts/test-terminal-batch.lua
@@ -27,11 +27,16 @@ local function run()
   add_repo_to_path()
 
   package.loaded["math-conceal.image.terminal"] = nil
-  package.loaded["math-conceal.image.state"] = package.loaded["math-conceal.image.state"]
-    or {
-      release_placement_id = function() end,
-      release_image_id = function() end,
-    }
+  local released_placements = {}
+  local released_images = {}
+  package.loaded["math-conceal.image.state"] = {
+    release_placement_id = function(id)
+      released_placements[#released_placements + 1] = id
+    end,
+    release_image_id = function(id)
+      released_images[#released_images + 1] = id
+    end,
+  }
 
   local writes = {}
   local original_ui_send = vim.api.nvim_ui_send
@@ -62,6 +67,16 @@ local function run()
   assert_eq("nested batch flushes at outer boundary", #writes, 3)
   assert_true("nested batch includes inner placement", writes[3]:find("p=13", 1, true) ~= nil)
   assert_true("nested batch includes outer placement", writes[3]:find("p=14", 1, true) ~= nil)
+
+  terminal.delete_placement(1, 15)
+  assert_eq("placement delete flushes immediately", #writes, 4)
+  assert_true("placement delete retains shared image data", writes[4]:find("d=i,i=1,p=15", 1, true) ~= nil)
+  assert_eq("placement id is released", released_placements[1], 15)
+
+  terminal.delete_image(1)
+  assert_eq("image delete flushes immediately", #writes, 5)
+  assert_true("image delete requests backing data release", writes[5]:find("d=I,i=1", 1, true) ~= nil)
+  assert_eq("image id is released", released_images[1], 1)
 
   vim.api.nvim_ui_send = original_ui_send
 end

--- a/service/src/compiler.rs
+++ b/service/src/compiler.rs
@@ -581,6 +581,7 @@ impl Compiler {
         };
 
         let render_req = RenderFormulasRequest {
+            lane: None,
             backend: None,
             request_id: req.request_id.clone(),
             cache_key: req.cache_key.clone(),
@@ -1426,6 +1427,7 @@ mod tests {
         .unwrap();
 
         let req = RenderFormulasRequest {
+            lane: None,
             backend: None,
             request_id: "formula:test".to_string(),
             cache_key: None,
@@ -1480,6 +1482,7 @@ mod tests {
         fs::create_dir_all(&output_dir).unwrap();
 
         let req = RenderFormulasRequest {
+            lane: None,
             backend: None,
             request_id: "formula:test".to_string(),
             cache_key: None,
@@ -1541,6 +1544,7 @@ mod tests {
         fs::create_dir_all(&output_dir).unwrap();
 
         let req = RenderFormulasRequest {
+            lane: None,
             backend: None,
             request_id: "formula:test".to_string(),
             cache_key: None,

--- a/service/src/latex.rs
+++ b/service/src/latex.rs
@@ -647,6 +647,7 @@ mod tests {
 
     fn latex_request(root: PathBuf, output_dir: PathBuf) -> RenderFormulasRequest {
         RenderFormulasRequest {
+            lane: None,
             backend: Some("latex".to_string()),
             request_id: "latex:test".to_string(),
             cache_key: None,

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -4,7 +4,7 @@ mod protocol;
 mod world;
 
 use std::collections::{HashMap, VecDeque};
-use std::io::{self, BufRead, Write};
+use std::io::{self, BufRead, BufWriter, Stdout, Write};
 use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
 
@@ -37,14 +37,28 @@ struct FormulaTask {
     cache_key: String,
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let stdin = io::stdin();
-    let mut stdout = io::BufWriter::new(io::stdout());
-    let mut compilers: HashMap<String, CachedCompiler> = HashMap::new();
-    let mut latex_renderer = LatexRenderer::new();
-    let mut use_clock: u64 = 0;
+type SharedStdout = Arc<Mutex<BufWriter<Stdout>>>;
 
-    for line in stdin.lock().lines() {
+// Full renders and live previews remain independently backpressured while
+// sharing one process and its immutable Typst world resources.
+enum LaneMessage {
+    Compile(protocol::CompileRequest),
+    RenderFormulas(RenderFormulasRequest),
+    RenderCodeFlow(RenderCodeFlowRequest),
+    Reset,
+    Shutdown,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let stdout = Arc::new(Mutex::new(BufWriter::new(io::stdout())));
+    let (full_tx, full_rx) = mpsc::channel();
+    let (preview_tx, preview_rx) = mpsc::channel();
+
+    let full_stdout = Arc::clone(&stdout);
+    let full_worker = thread::spawn(move || run_lane(full_rx, full_stdout));
+    let preview_worker = thread::spawn(move || run_lane(preview_rx, stdout));
+
+    for line in io::stdin().lock().lines() {
         let line = line?;
         if line.trim().is_empty() {
             continue;
@@ -58,8 +72,43 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         };
 
-        match msg {
-            IncomingMessage::Compile(req) => {
+        let sent = match msg {
+            IncomingMessage::Compile(req) => full_tx.send(LaneMessage::Compile(req)),
+            IncomingMessage::RenderFormulas(req) if req.lane.as_deref() == Some("preview") => {
+                preview_tx.send(LaneMessage::RenderFormulas(req))
+            }
+            IncomingMessage::RenderFormulas(req) => full_tx.send(LaneMessage::RenderFormulas(req)),
+            IncomingMessage::RenderCodeFlow(req) => full_tx.send(LaneMessage::RenderCodeFlow(req)),
+            IncomingMessage::ResetLane(req) if req.lane == "preview" => {
+                preview_tx.send(LaneMessage::Reset)
+            }
+            IncomingMessage::ResetLane(_) => full_tx.send(LaneMessage::Reset),
+            IncomingMessage::Shutdown => {
+                let _ = full_tx.send(LaneMessage::Shutdown);
+                let _ = preview_tx.send(LaneMessage::Shutdown);
+                break;
+            }
+        };
+        if sent.is_err() {
+            break;
+        }
+    }
+
+    drop(full_tx);
+    drop(preview_tx);
+    let _ = full_worker.join();
+    let _ = preview_worker.join();
+    Ok(())
+}
+
+fn run_lane(rx: mpsc::Receiver<LaneMessage>, stdout: SharedStdout) {
+    let mut compilers: HashMap<String, CachedCompiler> = HashMap::new();
+    let mut latex_renderer = LatexRenderer::new();
+    let mut use_clock: u64 = 0;
+
+    for msg in rx {
+        let result = match msg {
+            LaneMessage::Compile(req) => {
                 let cache_key = req
                     .cache_key
                     .clone()
@@ -75,35 +124,51 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 compiler.last_used = use_clock;
                 let resp = compiler.compiler.compile(req);
                 evict_stale_compilers(&mut compilers, &cache_key);
-                serde_json::to_writer(&mut stdout, &OutgoingMessage::CompileResult(resp))?;
-                stdout.write_all(b"\n")?;
-                stdout.flush()?;
+                write_message(&stdout, &OutgoingMessage::CompileResult(resp))
             }
-            IncomingMessage::RenderFormulas(req) => {
-                if req.backend.as_deref() == Some("latex") {
-                    render_latex_formulas(&mut stdout, req, &mut latex_renderer)?;
-                } else if formula_worker_count(&req) <= 1 {
-                    render_formulas_sequential(&mut stdout, req, &mut compilers, &mut use_clock)?;
-                } else {
-                    render_formulas_parallel(&mut stdout, req, &mut compilers, &mut use_clock)?;
-                }
+            LaneMessage::RenderFormulas(req) if req.backend.as_deref() == Some("latex") => {
+                render_latex_formulas(&stdout, req, &mut latex_renderer)
             }
-            IncomingMessage::RenderCodeFlow(req) => {
-                if code_flow_worker_count(&req) <= 1 {
-                    render_code_flow_sequential(&mut stdout, req, &mut compilers, &mut use_clock)?;
-                } else {
-                    render_code_flow_parallel(&mut stdout, req, &mut compilers, &mut use_clock)?;
-                }
+            LaneMessage::RenderFormulas(req) if formula_worker_count(&req) <= 1 => {
+                render_formulas_sequential(&stdout, req, &mut compilers, &mut use_clock)
             }
-            IncomingMessage::Shutdown => break,
+            LaneMessage::RenderFormulas(req) => {
+                render_formulas_parallel(&stdout, req, &mut compilers, &mut use_clock)
+            }
+            LaneMessage::RenderCodeFlow(req) if code_flow_worker_count(&req) <= 1 => {
+                render_code_flow_sequential(&stdout, req, &mut compilers, &mut use_clock)
+            }
+            LaneMessage::RenderCodeFlow(req) => {
+                render_code_flow_parallel(&stdout, req, &mut compilers, &mut use_clock)
+            }
+            LaneMessage::Reset => {
+                compilers.clear();
+                latex_renderer = LatexRenderer::new();
+                use_clock = 0;
+                Ok(())
+            }
+            LaneMessage::Shutdown => break,
+        };
+
+        if let Err(err) = result {
+            eprintln!("failed to process render request: {err}");
         }
     }
+}
 
+fn write_message(
+    stdout: &SharedStdout,
+    message: &OutgoingMessage,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut stdout = stdout.lock().map_err(|_| "stdout lock poisoned")?;
+    serde_json::to_writer(&mut *stdout, message)?;
+    stdout.write_all(b"\n")?;
+    stdout.flush()?;
     Ok(())
 }
 
 fn render_code_flow_sequential(
-    stdout: &mut impl Write,
+    stdout: &SharedStdout,
     req: RenderCodeFlowRequest,
     compilers: &mut HashMap<String, CachedCompiler>,
     use_clock: &mut u64,
@@ -131,7 +196,7 @@ fn render_code_flow_sequential(
 }
 
 fn render_code_flow_parallel(
-    stdout: &mut impl Write,
+    stdout: &SharedStdout,
     req: RenderCodeFlowRequest,
     compilers: &mut HashMap<String, CachedCompiler>,
     use_clock: &mut u64,
@@ -196,7 +261,7 @@ fn render_code_flow_parallel(
 }
 
 fn render_latex_formulas(
-    stdout: &mut impl Write,
+    stdout: &SharedStdout,
     req: RenderFormulasRequest,
     renderer: &mut LatexRenderer,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -208,7 +273,7 @@ fn render_latex_formulas(
 }
 
 fn render_formulas_sequential(
-    stdout: &mut impl Write,
+    stdout: &SharedStdout,
     req: RenderFormulasRequest,
     compilers: &mut HashMap<String, CachedCompiler>,
     use_clock: &mut u64,
@@ -238,7 +303,7 @@ fn render_formulas_sequential(
 }
 
 fn render_formulas_parallel(
-    stdout: &mut impl Write,
+    stdout: &SharedStdout,
     req: RenderFormulasRequest,
     compilers: &mut HashMap<String, CachedCompiler>,
     _use_clock: &mut u64,
@@ -389,23 +454,17 @@ fn code_flow_worker_count(req: &RenderCodeFlowRequest) -> usize {
 }
 
 fn write_formula_response(
-    stdout: &mut impl Write,
+    stdout: &SharedStdout,
     resp: FormulaRenderResponse,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    serde_json::to_writer(stdout.by_ref(), &OutgoingMessage::FormulaRendered(resp))?;
-    stdout.write_all(b"\n")?;
-    stdout.flush()?;
-    Ok(())
+    write_message(stdout, &OutgoingMessage::FormulaRendered(resp))
 }
 
 fn write_code_flow_response(
-    stdout: &mut impl Write,
+    stdout: &SharedStdout,
     resp: CodeFlowRenderResponse,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    serde_json::to_writer(stdout.by_ref(), &OutgoingMessage::CodeFlowRendered(resp))?;
-    stdout.write_all(b"\n")?;
-    stdout.flush()?;
-    Ok(())
+    write_message(stdout, &OutgoingMessage::CodeFlowRendered(resp))
 }
 
 fn evict_stale_compilers(compilers: &mut HashMap<String, CachedCompiler>, active_key: &str) {
@@ -439,6 +498,7 @@ mod tests {
     #[test]
     fn render_formulas_rejects_code_nodes() {
         let req = RenderFormulasRequest {
+            lane: None,
             backend: None,
             request_id: "formula:test".to_string(),
             cache_key: None,

--- a/service/src/protocol.rs
+++ b/service/src/protocol.rs
@@ -12,6 +12,8 @@ pub enum IncomingMessage {
     RenderFormulas(RenderFormulasRequest),
     #[serde(rename = "render_code_flow")]
     RenderCodeFlow(RenderCodeFlowRequest),
+    #[serde(rename = "reset_lane")]
+    ResetLane(ResetLaneRequest),
     #[serde(rename = "shutdown")]
     Shutdown,
 }
@@ -29,8 +31,15 @@ pub struct CompileRequest {
     pub ppi: u32,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct ResetLaneRequest {
+    pub lane: String,
+}
+
 #[derive(Clone, Debug, Deserialize)]
 pub struct RenderFormulasRequest {
+    #[serde(default)]
+    pub lane: Option<String>,
     #[serde(default)]
     pub backend: Option<String>,
     pub request_id: String,
@@ -252,6 +261,41 @@ pub enum FlowRole {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn decodes_preview_lane_reset() {
+        let req: IncomingMessage =
+            serde_json::from_str(r#"{"type":"reset_lane","lane":"preview"}"#).unwrap();
+        match req {
+            IncomingMessage::ResetLane(req) => assert_eq!(req.lane, "preview"),
+            _ => panic!("expected reset_lane request"),
+        }
+    }
+
+    #[test]
+    fn decodes_preview_formula_lane() {
+        let req: IncomingMessage = serde_json::from_str(
+            r##"{
+              "type":"render_formulas",
+              "lane":"preview",
+              "request_id":"preview:1",
+              "context_id":"ctx",
+              "context_rev":1,
+              "root":"/tmp",
+              "output_dir":"/tmp/out",
+              "ppi":144,
+              "nodes":[]
+            }"##,
+        )
+        .unwrap();
+
+        match req {
+            IncomingMessage::RenderFormulas(req) => {
+                assert_eq!(req.lane.as_deref(), Some("preview"));
+            }
+            _ => panic!("expected render_formulas request"),
+        }
+    }
 
     #[test]
     fn decodes_latex_formula_request() {

--- a/service/src/world.rs
+++ b/service/src/world.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::SystemTime;
 
 use time::OffsetDateTime;
@@ -15,14 +15,60 @@ use typst_kit::download::{Downloader, ProgressSink};
 use typst_kit::fonts::{FontSlot, Fonts};
 use typst_kit::package::PackageStorage;
 
+type LibraryKey = Vec<(String, String)>;
+type SharedLibraries = Mutex<HashMap<LibraryKey, Arc<LazyHash<Library>>>>;
+
+// Expensive immutable Typst resources are process-wide so full and preview
+// lane compilers do not repeat font discovery or package/library state.
+struct SharedWorldResources {
+    book: LazyHash<FontBook>,
+    fonts: Vec<FontSlot>,
+    packages: PackageStorage,
+    libraries: SharedLibraries,
+}
+
+fn shared_world_resources() -> Arc<SharedWorldResources> {
+    static SHARED: OnceLock<Arc<SharedWorldResources>> = OnceLock::new();
+    Arc::clone(SHARED.get_or_init(|| {
+        let fonts = Fonts::searcher().search();
+        Arc::new(SharedWorldResources {
+            book: LazyHash::new(fonts.book),
+            fonts: fonts.fonts,
+            packages: PackageStorage::new(
+                std::env::var_os("TYPST_PACKAGE_CACHE_PATH").map(PathBuf::from),
+                std::env::var_os("TYPST_PACKAGE_PATH").map(PathBuf::from),
+                Downloader::new("typst-concealer-service"),
+            ),
+            libraries: Mutex::new(HashMap::new()),
+        })
+    }))
+}
+
+fn shared_library(
+    shared: &SharedWorldResources,
+    inputs: &HashMap<String, String>,
+) -> Arc<LazyHash<Library>> {
+    let mut key: Vec<_> = inputs
+        .iter()
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect();
+    key.sort_unstable();
+    let mut libraries = shared.libraries.lock().unwrap();
+    Arc::clone(libraries.entry(key).or_insert_with(|| {
+        Arc::new(LazyHash::new(
+            Library::builder()
+                .with_inputs(to_dict(inputs.clone()))
+                .build(),
+        ))
+    }))
+}
+
 pub struct ConcealerWorld {
     entry_id: FileId,
     source: Source,
     root: PathBuf,
-    library: LazyHash<Library>,
-    book: LazyHash<FontBook>,
-    fonts: Vec<FontSlot>,
-    packages: PackageStorage,
+    library: Arc<LazyHash<Library>>,
+    shared: Arc<SharedWorldResources>,
     virtual_sources: Mutex<HashMap<FileId, Source>>,
     sources: Mutex<HashMap<FileId, Source>>,
     files: Mutex<HashMap<FileId, Bytes>>,
@@ -33,19 +79,13 @@ pub struct ConcealerWorld {
 impl ConcealerWorld {
     pub fn new() -> Self {
         let entry_id = FileId::new(None, VirtualPath::new("/main.typ"));
-        let fonts = Fonts::searcher().search();
+        let shared = shared_world_resources();
         Self {
             entry_id,
             source: Source::new(entry_id, String::new()),
             root: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
-            library: LazyHash::new(Library::default()),
-            book: LazyHash::new(fonts.book),
-            fonts: fonts.fonts,
-            packages: PackageStorage::new(
-                std::env::var_os("TYPST_PACKAGE_CACHE_PATH").map(PathBuf::from),
-                std::env::var_os("TYPST_PACKAGE_PATH").map(PathBuf::from),
-                Downloader::new("typst-concealer-service"),
-            ),
+            library: shared_library(&shared, &HashMap::new()),
+            shared,
             virtual_sources: Mutex::new(HashMap::new()),
             sources: Mutex::new(HashMap::new()),
             files: Mutex::new(HashMap::new()),
@@ -78,11 +118,7 @@ impl ConcealerWorld {
 
         // Phase 1: Only rebuild library when inputs change
         if inputs != self.prev_inputs {
-            self.library = LazyHash::new(
-                Library::builder()
-                    .with_inputs(to_dict(inputs.clone()))
-                    .build(),
-            );
+            self.library = shared_library(&self.shared, &inputs);
             self.prev_inputs = inputs;
         }
 
@@ -170,7 +206,7 @@ impl ConcealerWorld {
 
         if let Some(spec) = id.package() {
             let mut progress = ProgressSink;
-            let root = self.packages.prepare_package(spec, &mut progress)?;
+            let root = self.shared.packages.prepare_package(spec, &mut progress)?;
             return id
                 .vpath()
                 .resolve(&root)
@@ -189,7 +225,7 @@ impl World for ConcealerWorld {
     }
 
     fn book(&self) -> &LazyHash<FontBook> {
-        &self.book
+        &self.shared.book
     }
 
     fn main(&self) -> FileId {
@@ -252,7 +288,7 @@ impl World for ConcealerWorld {
     }
 
     fn font(&self, index: usize) -> Option<Font> {
-        self.fonts.get(index)?.get()
+        self.shared.fonts.get(index)?.get()
     }
 
     fn today(&self, offset: Option<i64>) -> Option<Datetime> {


### PR DESCRIPTION
## Summary

- run full renders and live previews as independent lanes in one Rust service process per buffer
- share Typst font discovery, font book, package storage, and input libraries across lane-local compilers
- preserve latest-only preview and merged full-render backpressure; reset only preview compiler state after preview idle
- release retired Kitty image backing data while preserving placement-only deletion semantics
- add shared-service, concurrent-lane, and terminal protocol regression tests

## Performance

Replaying the supplied live Neovim workbench workload (10 formula renders, 4 code-flow renders, 1 live preview), five-run medians changed from:

- peak RSS: 128.5 MiB -> 54.2 MiB (-57.8%)
- complete render time: 962 ms -> 204 ms (-78.8%)
- preview first response: 220 ms -> 193 ms (-12.3%)

A warmed 400-formula stress run reduced peak RSS from 110.6 MiB to 38.9 MiB while keeping preview independently responsive.

## Validation

- `cargo test --manifest-path service/Cargo.toml` (26 tests)
- `cargo check --manifest-path service/Cargo.toml`
- `python3 scripts/test-service-lanes.py service/target/release/typst-concealer-service`
- shared-service, preview-idle, hidden-service, terminal-batch, and window-node-slot headless tests
- `stylua --check`
- LuaJIT bytecode checks
- `git diff --check`
